### PR TITLE
Add tests for the CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ cache:
   directories:
     - $HOME/.pip-cache/
 install:
-  - "travis_retry pip install setuptools --upgrade"
-  - "travis_retry pip install tox"
+  - 'travis_retry pip install setuptools --upgrade'
+  - 'travis_retry pip install tox'
 script:
   - tox -e $TOX_ENV
 after_script:

--- a/populus/cli.py
+++ b/populus/cli.py
@@ -3,7 +3,7 @@ import os
 import click
 
 from populus import utils
-from populus.client import Client
+from eth_rpc_client import Client
 
 
 @click.group()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 python_paths= .
 addopts= --tb native -v
+norecursedirs='tests/*/projects'

--- a/tests/command_line_interface/conftest.py
+++ b/tests/command_line_interface/conftest.py
@@ -1,0 +1,17 @@
+import os
+import shutil
+
+import pytest
+
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+@pytest.fixture(autouse=True)
+def cleanup_build_dirs():
+    """
+    Remove the build dirs that are created during test runs.
+    """
+    build_dir = os.path.join(BASE_DIR, './projects/test-01/build/')
+    if os.path.exists(build_dir):
+        shutil.rmtree(build_dir)

--- a/tests/command_line_interface/projects/test-01/contracts/owned.sol
+++ b/tests/command_line_interface/projects/test-01/contracts/owned.sol
@@ -1,0 +1,7 @@
+contract owned {
+        address owner;
+
+        function owned() {
+                owner = msg.sender;
+        }
+}

--- a/tests/command_line_interface/projects/test-02/build/contracts.json
+++ b/tests/command_line_interface/projects/test-02/build/contracts.json
@@ -1,0 +1,19 @@
+{
+    "owned": {
+        "code": "0x60606040525b33600060006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908302179055505b600a80603e6000396000f30060606040526008565b00",
+        "info": {
+            "abiDefinition": [
+                {
+                    "inputs": [],
+                    "type": "constructor"
+                }
+            ],
+            "compilerVersion": "0.9.73",
+            "developerDoc": null,
+            "language": "Solidity",
+            "languageVersion": "0",
+            "source": "contract owned {\n        address owner;\n\n        function owned() {\n                owner = msg.sender;\n        }\n}\n",
+            "userDoc": null
+        }
+    }
+}

--- a/tests/command_line_interface/projects/test-02/contracts/owned.sol
+++ b/tests/command_line_interface/projects/test-02/contracts/owned.sol
@@ -1,0 +1,7 @@
+contract owned {
+        address owner;
+
+        function owned() {
+                owner = msg.sender;
+        }
+}

--- a/tests/command_line_interface/projects/test-03/build/contracts.json
+++ b/tests/command_line_interface/projects/test-03/build/contracts.json
@@ -1,0 +1,19 @@
+{
+    "owned": {
+        "code": "0x60606040525b33600060006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908302179055505b600a80603e6000396000f30060606040526008565b00",
+        "info": {
+            "abiDefinition": [
+                {
+                    "inputs": [],
+                    "type": "constructor"
+                }
+            ],
+            "compilerVersion": "0.9.73",
+            "developerDoc": null,
+            "language": "Solidity",
+            "languageVersion": "0",
+            "source": "contract owned {\n        address owner;\n\n        function owned() {\n                owner = msg.sender;\n        }\n}\n",
+            "userDoc": null
+        }
+    }
+}

--- a/tests/command_line_interface/projects/test-03/contracts/owned.sol
+++ b/tests/command_line_interface/projects/test-03/contracts/owned.sol
@@ -1,0 +1,7 @@
+contract owned {
+        address owner;
+
+        function owned() {
+                owner = msg.sender;
+        }
+}

--- a/tests/command_line_interface/projects/test-03/tests/test_passing_tests.py
+++ b/tests/command_line_interface/projects/test-03/tests/test_passing_tests.py
@@ -1,0 +1,2 @@
+def test_that_passes():
+    assert True

--- a/tests/command_line_interface/projects/test-04/build/contracts.json
+++ b/tests/command_line_interface/projects/test-04/build/contracts.json
@@ -1,0 +1,19 @@
+{
+    "owned": {
+        "code": "0x60606040525b33600060006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908302179055505b600a80603e6000396000f30060606040526008565b00",
+        "info": {
+            "abiDefinition": [
+                {
+                    "inputs": [],
+                    "type": "constructor"
+                }
+            ],
+            "compilerVersion": "0.9.73",
+            "developerDoc": null,
+            "language": "Solidity",
+            "languageVersion": "0",
+            "source": "contract owned {\n        address owner;\n\n        function owned() {\n                owner = msg.sender;\n        }\n}\n",
+            "userDoc": null
+        }
+    }
+}

--- a/tests/command_line_interface/projects/test-04/contracts/owned.sol
+++ b/tests/command_line_interface/projects/test-04/contracts/owned.sol
@@ -1,0 +1,7 @@
+contract owned {
+        address owner;
+
+        function owned() {
+                owner = msg.sender;
+        }
+}

--- a/tests/command_line_interface/projects/test-04/tests/test_failing_tests.py
+++ b/tests/command_line_interface/projects/test-04/tests/test_failing_tests.py
@@ -1,0 +1,2 @@
+def test_that_fails():
+    assert False

--- a/tests/command_line_interface/test_compilation.py
+++ b/tests/command_line_interface/test_compilation.py
@@ -1,0 +1,17 @@
+import pytest
+import click
+from click.testing import CliRunner
+
+from ethereum._solidity import get_solidity
+
+from populus.cli import main
+
+
+@pytest.mark.skipif(get_solidity() is None, reason="'solc' compiler not available")
+def test_compiling(monkeypatch):
+    monkeypatch.chdir('./tests/command_line_interface/projects/test-01/')
+    runner = CliRunner()
+    result = runner.invoke(main, ['compile'])
+
+    assert result.exit_code == 0, result.output
+    assert result.output == 'Compiling!\n'

--- a/tests/command_line_interface/test_deployment.py
+++ b/tests/command_line_interface/test_deployment.py
@@ -1,0 +1,18 @@
+import re
+import click
+from click.testing import CliRunner
+
+from populus.cli import main
+
+
+def test_deployment(rpc_server, monkeypatch):
+    monkeypatch.chdir('./tests/command_line_interface/projects/test-02/')
+    runner = CliRunner()
+    result = runner.invoke(main, ['deploy'])
+
+    assert result.exit_code == 0, result.output
+
+    # weak assertion but not sure what to do here.
+    assert 'owned' in result.output
+    assert re.search(' (0x[0-9a-f]{40}) ', result.output)
+    assert re.search(' (txn:0x[0-9a-f]{64})', result.output)

--- a/tests/command_line_interface/test_running_tests.py
+++ b/tests/command_line_interface/test_running_tests.py
@@ -1,0 +1,27 @@
+import re
+import click
+from click.testing import CliRunner
+
+from populus.cli import main
+
+
+def test_running_tests_that_pass(monkeypatch):
+    monkeypatch.chdir('./tests/command_line_interface/projects/test-03/')
+    runner = CliRunner()
+    result = runner.invoke(main, ['test'])
+
+    assert result.exit_code == 0, result.output
+
+    # weak assertion but not sure what to do here.
+    assert 'test_that_passes' in result.output
+
+
+def test_running_tests_that_fail(monkeypatch):
+    monkeypatch.chdir('./tests/command_line_interface/projects/test-04/')
+    runner = CliRunner()
+    result = runner.invoke(main, ['test'])
+
+    assert result.exit_code == 0, result.output
+
+    # weak assertion but not sure what to do here.
+    assert 'test_that_fails' in result.output


### PR DESCRIPTION
the `0.1.3` broke the CLI because of a bad import in the `populus.cli` module.  This would have been easily caught if there were tests for the CLI.

So, here are some really basic CLI tests.

#### Cute animal picture.

![f49a8229df479bf48f0dc22f32a08214](https://cloud.githubusercontent.com/assets/824194/9390575/32895cee-472f-11e5-98a9-9781adc16a03.jpg)
