### PR TITLE
enable bool response values from contracts

### DIFF
--- a/populus/contracts.py
+++ b/populus/contracts.py
@@ -33,9 +33,6 @@ class BoundFunction(object):
 def decode_single(typ, data):
     base, sub, _ = abi.process_type(typ)
 
-    if sub != '256':
-        raise NotImplementedError('havent gotten to this, {0}'.format((base, sub, _)))
-
     if base == 'address':
         raise NotImplementedError('havent gotten to this')
         # return encode_hex(data[12:])
@@ -56,8 +53,7 @@ def decode_single(typ, data):
         high, low = [int(x) for x in sub.split('x')]
         # return (big_endian_to_int(data) * 1.0 / 2 ** low) % 2 ** high
     elif base == 'bool':
-        raise NotImplementedError('havent gotten to this')
-        # return bool(int(data.encode('hex'), 16))
+        return bool(int(data, 16))
     else:
         raise ValueError("Unknown base: `{0}`".format(base))
 

--- a/tests/contracts/test_decode_single_type.py
+++ b/tests/contracts/test_decode_single_type.py
@@ -29,3 +29,15 @@ def test_decode_int256(input, expected):
 def test_decode_uint256(input, expected):
     output = decode_single('uint256', input)
     assert output == expected
+
+
+@pytest.mark.parametrize(
+    'input,expected',
+    (
+        ('0x0000000000000000000000000000000000000000000000000000000000000001', True),
+        ('0x0000000000000000000000000000000000000000000000000000000000000000', False),
+    )
+)
+def test_decode_bool(input, expected):
+    output = decode_single('bool', input)
+    assert output == expected


### PR DESCRIPTION
Enable `boolean` return values from contract `function.call(..)` calls.

#### Cute animal picture

![tumblr_mgc1aqr2dz1r3n418o1_500](https://cloud.githubusercontent.com/assets/824194/9413845/ca7269b6-47f1-11e5-99a0-bc83d6494cf6.jpg)
