### PR TITLE
add bytes decoding

### DIFF
--- a/populus/contracts.py
+++ b/populus/contracts.py
@@ -37,8 +37,8 @@ def decode_single(typ, data):
         raise NotImplementedError('havent gotten to this')
         # return encode_hex(data[12:])
     elif base == 'string' or base == 'bytes' or base == 'hash':
-        raise NotImplementedError('havent gotten to this')
-        # return data[:int(sub)] if len(sub) else data
+        bytes = ethereum_utils.int_to_32bytearray(int(data, 16))
+        return ''.join(chr(b) for b in bytes if b)
     elif base == 'uint':
         return int(data, 16)
     elif base == 'int':

--- a/tests/contracts/test_decode_single_type.py
+++ b/tests/contracts/test_decode_single_type.py
@@ -41,3 +41,22 @@ def test_decode_uint256(input, expected):
 def test_decode_bool(input, expected):
     output = decode_single('bool', input)
     assert output == expected
+
+
+@pytest.mark.parametrize(
+    'input,expected',
+    (
+        ('0x7465737400000000000000000000000000000000000000000000000000000000', 'test'),
+        (
+            '0x6162636465666768696a6b6c6d6e6f707172737475767778797a000000000000',
+            'abcdefghijklmnopqrstuvwxyz',
+        ),
+        (
+            '0x3031323334353637383921402324255e262a2829000000000000000000000000',
+            '0123456789!@#$%^&*()',
+        ),
+    )
+)
+def test_decode_bytes32(input, expected):
+    output = decode_single('bytes32', input)
+    assert output == expected


### PR DESCRIPTION
Enable the decoding of `bytes` types for contract return values.

#### Cute animal picture

![f80751d2c95bb167680624180b10349b](https://cloud.githubusercontent.com/assets/824194/9419197/da7cee56-4816-11e5-916c-9483852c8b79.jpg)
