### PR TITLE
Fix contract bug

### DIFF
--- a/docs/populus.contracts.rst
+++ b/docs/populus.contracts.rst
@@ -61,6 +61,12 @@ The JSON RPC client this contract will use.
 The contract ABI.
 
 
+``ContractClass.get_balance(block="latest")``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Returns contract balance in wei as an integer.
+
+
 ``populus.contracts.Function(name, inputs, outputs=None, constant=False):``
 ---------------------------------------------------------------------------
 

--- a/populus/contracts.py
+++ b/populus/contracts.py
@@ -18,9 +18,9 @@ class BoundFunction(object):
         data = self.function.get_call_data(args)
 
         return self.client.send_transaction(
-            _from=kwargs['_from'],
             to=self.address,
             data=data,
+            **kwargs
         )
 
     def call(self, *args, **kwargs):
@@ -162,6 +162,9 @@ class ContractBase(object):
         return cls.client.send_transaction(
             _from, gas, gas_price, value, data=cls.code,
         )
+
+    def get_balance(self, block="latest"):
+        return self.client.get_balance(self.address, block=block)
 
 
 def Contract(client, contract_name, contract):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click>=5.0
-ethereum-rpc-client==0.1.0
+ethereum-rpc-client==0.1.2
 ethereum>=0.9.73
 https://github.com/ethereum/ethash/archive/v23.1.tar.gz
 eth-testrpc>=0.1.16

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "requests>=2.7.0",
         "eth-testrpc>=0.1.16",
         "pytest>=2.7.2",
-        "ethereum-rpc-client>=0.1.0",
+        "ethereum-rpc-client>=0.1.2",
         "watchdog==0.8.3",
     ],
     dependency_links=[

--- a/tests/contracts/test_contract_object.py
+++ b/tests/contracts/test_contract_object.py
@@ -109,3 +109,9 @@ def test_contract_function_call_multiply7(math, eth_coinbase):
 def test_contract_function_call_add(math, eth_coinbase):
     ret = math.add.call(25, 35, _from=eth_coinbase)
     assert ret == 60
+
+
+def test_sent_transaction_with_value(math, eth_coinbase, rpc_client):
+    assert math.get_balance() == 0
+    txn_hash = math.add.sendTransaction(35, 45, _from=eth_coinbase, value=1000)
+    assert math.get_balance() == 1000


### PR DESCRIPTION
Fixes a bug where the `value` and other `**kwargs` parameters in `Contract.sendTransaction` were not being passed along to the `sendTransaction` method on the rpc client.

![pet-birthday-1](https://cloud.githubusercontent.com/assets/824194/9420109/51efbb46-481f-11e5-892a-4f42b981871d.jpg)
