### PR TITLE
Piper/enable constructor with params

### DIFF
--- a/docs/populus.contracts.rst
+++ b/docs/populus.contracts.rst
@@ -31,10 +31,12 @@ Instantiate an instance of your contract with the ``hex`` encoded address of
 where it is deployed.
 
 
-``ContractClass.deploy(_from=None, gas=None, gas_price=None, value=None)``
+``ContractClass.deploy(_from=None, gas=None, gas_price=None, value=None, args=None)``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``classmethod`` for deploying the contract. Returns the transaction hash.
+``classmethod`` for deploying the contract. Returns the transaction hash.  If
+the contract constructor takes arguments, they should be passed in as the
+``constructor_args`` argument.
 
 
 ``ContractClass.code``

--- a/populus/contracts.py
+++ b/populus/contracts.py
@@ -160,10 +160,10 @@ class ContractBase(object):
         return "{name}({address})".format(name=self.__class__.__name__, address=self.address)
 
     @classmethod
-    def deploy(cls, _from=None, gas=None, gas_price=None, value=None, args=None):
+    def deploy(cls, _from=None, gas=None, gas_price=None, value=None, constructor_args=None):
         data = cls.code
-        if args:
-            data += ethereum_utils.encode_hex(cls.constructor.abi_args_signature(args))
+        if constructor_args:
+            data += ethereum_utils.encode_hex(cls.constructor.abi_args_signature(constructor_args))
 
         return cls.client.send_transaction(
             _from, gas, gas_price, value, data=data,

--- a/populus/contracts.py
+++ b/populus/contracts.py
@@ -163,8 +163,7 @@ class ContractBase(object):
     def deploy(cls, _from=None, gas=None, gas_price=None, value=None, args=None):
         data = cls.code
         if args:
-            data += cls.constructor.get_call_data(args)
-            import ipdb; ipdb.set_trace()
+            data += ethereum_utils.encode_hex(cls.constructor.abi_args_signature(args))
 
         return cls.client.send_transaction(
             _from, gas, gas_price, value, data=data,

--- a/populus/contracts.py
+++ b/populus/contracts.py
@@ -134,7 +134,6 @@ class Function(object):
 
     def __get__(self, obj, type=None):
         if obj is None:
-            # TODO: this is sorta odd behavior.
             return self
         bound_function = BoundFunction(
             function=self,
@@ -161,9 +160,14 @@ class ContractBase(object):
         return "{name}({address})".format(name=self.__class__.__name__, address=self.address)
 
     @classmethod
-    def deploy(cls, _from=None, gas=None, gas_price=None, value=None):
+    def deploy(cls, _from=None, gas=None, gas_price=None, value=None, args=None):
+        data = cls.code
+        if args:
+            data += cls.constructor.get_call_data(args)
+            import ipdb; ipdb.set_trace()
+
         return cls.client.send_transaction(
-            _from, gas, gas_price, value, data=cls.code,
+            _from, gas, gas_price, value, data=data,
         )
 
     def get_balance(self, block="latest"):
@@ -185,6 +189,11 @@ def Contract(client, contract_name, contract):
     for signature_item in _abi:
         if signature_item['type'] == 'constructor':
             # Constructors don't need to be part of a contract's methods
+            if signature_item.get('inputs'):
+                _dict['constructor'] = Function(
+                    name='constructor',
+                    inputs=signature_item['inputs'],
+                )
             continue
 
         if signature_item['name'] in _dict:

--- a/tests/contracts/test_contracts_constructor_with_args.py
+++ b/tests/contracts/test_contracts_constructor_with_args.py
@@ -1,0 +1,63 @@
+import pytest
+
+from eth_rpc_client import Client
+
+from populus.contracts import Contract
+
+from ethereum import utils as ethereum_utils
+
+
+contract = {
+    "code": "0x606060405260405160208060948339016040526060805190602001505b806000600050819055505b50605f8060356000396000f30060606040526000357c01000000000000000000000000000000000000000000000000000000009004806306fdde03146037576035565b005b60406004506056565b6040518082815260200191505060405180910390f35b6000600050548156",
+    "info": {
+        "abiDefinition": [
+            {
+                "constant": True,
+                "inputs": [],
+                "name": "name",
+                "outputs": [
+                    {
+                        "name": "",
+                        "type": "bytes32"
+                    }
+                ],
+                "type": "function"
+            },
+            {
+                "inputs": [
+                    {
+                        "name": "_name",
+                        "type": "bytes32"
+                    }
+                ],
+                "type": "constructor"
+            }
+        ],
+        "compilerVersion": "0.9.74",
+        "developerDoc": {
+            "methods": {}
+        },
+        "language": "Solidity",
+        "languageVersion": "0",
+        "source": "contract Named {\n        bytes32 public name;\n\n        function Named(bytes32 _name) {\n                name = _name;\n        }\n}\n",
+        "userDoc": {
+            "methods": {}
+        }
+    }
+}
+
+
+@pytest.fixture
+def Math(rpc_client):
+    Math = Contract(rpc_client, 'Math', contract)
+    return Math
+
+
+def test_constructor_with_args(rpc_server, rpc_client, Math, eth_coinbase):
+    deploy_txn_hash = Math.deploy(_from=eth_coinbase, args=("John",))
+    receipt = rpc_client.get_transaction_receipt(deploy_txn_hash)
+    assert receipt
+    assert receipt['contractAddress']
+    math = Math(receipt['contractAddress'])
+    name = math.name.call(_from=eth_coinbase)
+    assert name == "John"

--- a/tests/contracts/test_contracts_constructor_with_args.py
+++ b/tests/contracts/test_contracts_constructor_with_args.py
@@ -54,7 +54,7 @@ def Math(rpc_client):
 
 
 def test_constructor_with_args(rpc_server, rpc_client, Math, eth_coinbase):
-    deploy_txn_hash = Math.deploy(_from=eth_coinbase, args=("John",))
+    deploy_txn_hash = Math.deploy(_from=eth_coinbase, constructor_args=("John",))
     receipt = rpc_client.get_transaction_receipt(deploy_txn_hash)
     assert receipt
     assert receipt['contractAddress']


### PR DESCRIPTION
This adds support for contracts who's constructors take arguments via the new `constructor_args` parameter that the `deploy` method takes.

![chihuahua-birthday-hat-256931](https://cloud.githubusercontent.com/assets/824194/9424441/19d7e31a-48aa-11e5-8092-74001ee20ff1.jpg)
