### PR TITLE
Enable decoding of address return values from contracts

### DIFF
--- a/populus/contracts.py
+++ b/populus/contracts.py
@@ -34,8 +34,7 @@ def decode_single(typ, data):
     base, sub, _ = abi.process_type(typ)
 
     if base == 'address':
-        raise NotImplementedError('havent gotten to this')
-        # return encode_hex(data[12:])
+        return '0x' + data[-40:]
     elif base == 'string' or base == 'bytes' or base == 'hash':
         bytes = ethereum_utils.int_to_32bytearray(int(data, 16))
         while bytes and bytes[-1] == 0:

--- a/tests/contracts/test_decode_single_type.py
+++ b/tests/contracts/test_decode_single_type.py
@@ -64,3 +64,29 @@ def test_decode_bool(input, expected):
 def test_decode_bytes32(input, expected):
     output = decode_single('bytes32', input)
     assert output == expected
+
+
+@pytest.mark.parametrize(
+    'input,expected',
+    (
+        (
+            '0x000000000000000000000000c305c901078781c232a2a521c2af7980f8385ee9',
+            '0xc305c901078781c232a2a521c2af7980f8385ee9',
+        ),
+        (
+            '0x0000000000000000000000000005c901078781c232a2a521c2af7980f8385ee9',
+            '0x0005c901078781c232a2a521c2af7980f8385ee9',
+        ),
+        (
+            '0x000000000000000000000000c305c901078781c232a2a521c2af7980f8385000',
+            '0xc305c901078781c232a2a521c2af7980f8385000',
+        ),
+        (
+            '0x0000000000000000000000000005c901078781c232a2a521c2af7980f8385000',
+            '0x0005c901078781c232a2a521c2af7980f8385000',
+        ),
+    )
+)
+def test_decode_address(input, expected):
+    output = decode_single('address', input)
+    assert output == expected


### PR DESCRIPTION
Enable decoding of `address` types from contract return values

![dog-happy-birthday-hats-that-ate-the-cutest](https://cloud.githubusercontent.com/assets/824194/9426196/7a4e8bc4-48ee-11e5-8538-5c82c594b0b4.jpg)
