### PR TITLE
Piper/vendor solidity wrapper

### DIFF
--- a/populus/compilation.py
+++ b/populus/compilation.py
@@ -4,14 +4,11 @@ import os
 import json
 import functools
 
-import ethereum
-
-from ethereum._solidity import get_solidity
-
 from populus.utils import (
     get_contracts_dir,
     get_build_dir,
 )
+from populus.solidity import solc
 
 
 def find_project_contracts(project_dir):
@@ -45,37 +42,11 @@ def write_compiled_sources(project_dir, compiled_sources):
     return file_path
 
 
-def _compile_rich(compiler, code):
-    """
-    Shim for the `compile_rich` functionality from `pyethereum` which is not
-    currently available on pypi as of 2015-08-18
-    """
-    return {
-        contract_name: {
-            'code': "0x" + contract.get('binary'),
-            'info': {
-                'abiDefinition': contract.get('json-abi'),
-                'compilerVersion': ethereum.__version__,
-                'developerDoc': contract.get('natspec-dev'),
-                'language': 'Solidity',
-                'languageVersion': '0',
-                'source': code,
-                'userDoc': contract.get('natspec-user')
-            },
-        }
-        for contract_name, contract
-        in compiler.combined(code)
-    }
-
-
 def get_compiler_for_file(file_path):
     _, _, ext = file_path.rpartition('.')
 
     if ext == 'sol':
-        compiler = get_solidity()
-        if compiler is None:
-            raise ValueError("No solidity compiler")
-        return compiler
+        return solc
     elif ext == 'lll':
         raise ValueError("Compilation of LLL contracts is not yet supported")
     elif ext == 'mu':
@@ -93,7 +64,7 @@ def compile_source_file(source_path):
         source_code = source_file.read()
 
     # TODO: solidity specific
-    compiled_source = _compile_rich(compiler, source_code)
+    compiled_source = compiler(source_code)
     return compiled_source
 
 

--- a/populus/solidity.py
+++ b/populus/solidity.py
@@ -41,7 +41,9 @@ def solc_version():
     return version
 
 
-def solc(source=None, input_files=None, add_std=True, combined_json='json-abi,binary,sol-abi,natspec-dev,natspec-user', raw=False, rich=True):
+def solc(source=None, input_files=None, add_std=True,
+         combined_json='json-abi,binary,sol-abi,natspec-dev,natspec-user',
+         raw=False, rich=True):
 
     if source and input_files:
         raise ValueError("`source` and `input_files` are mutually exclusive")

--- a/populus/solidity.py
+++ b/populus/solidity.py
@@ -1,5 +1,8 @@
+import os
 import subprocess
 import itertools
+import yaml
+import re
 
 
 class CompileError(Exception):
@@ -9,7 +12,36 @@ class CompileError(Exception):
 SOLC_BINARY = 'solc'
 
 
-def solc(source=None, input_files=None, add_std=True, combined_json='json-abi,binary,sol-abi,natspec-dev,natspec-user'):
+version_regex = re.compile('Version: ([0-9]+\.[0-9]+\.[0-9]+(-[a-f0-9]+)?)')
+
+
+def is_solc_available():
+    program = 'solc'
+
+    def is_exe(fpath):
+        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+    fpath = os.path.dirname(program)
+    if fpath:
+        if is_exe(program):
+            return True
+    else:
+        for path in os.environ["PATH"].split(os.pathsep):
+            path = path.strip('"')
+            exe_file = os.path.join(path, program)
+            if is_exe(exe_file):
+                return True
+
+    return False
+
+
+def solc_version():
+    version_string = subprocess.check_output(['solc', '--version'])
+    version = version_regex.search(version_string).groups()[0]
+    return version
+
+
+def solc(source=None, input_files=None, add_std=True, combined_json='json-abi,binary,sol-abi,natspec-dev,natspec-user', raw=False, rich=True):
 
     if source and input_files:
         raise ValueError("`source` and `input_files` are mutually exclusive")
@@ -35,4 +67,38 @@ def solc(source=None, input_files=None, add_std=True, combined_json='json-abi,bi
 
     if p.returncode:
         raise CompileError('compilation failed')
-    return stdoutdata
+
+    if raw:
+        return stdoutdata
+
+    contracts = yaml.safe_load(stdoutdata)['contracts']
+
+    for contract_name, data in contracts.items():
+        data['json-abi'] = yaml.safe_load(data['json-abi'])
+        data['sol-abi'] = yaml.safe_load(data['sol-abi'])
+        data['natspec-dev'] = yaml.safe_load(data['natspec-dev'])
+        data['natspec-user'] = yaml.safe_load(data['natspec-user'])
+
+    sorted_contracts = sorted(contracts.items(), key=lambda c: c[0])
+
+    if not rich:
+        return sorted_contracts
+
+    compiler_version = solc_version()
+
+    return {
+        contract_name: {
+            'code': "0x" + contract.get('binary'),
+            'info': {
+                'abiDefinition': contract.get('json-abi'),
+                'compilerVersion': compiler_version,
+                'developerDoc': contract.get('natspec-dev'),
+                'language': 'Solidity',
+                'languageVersion': '0',
+                'source': source,  # what to do for files?
+                'userDoc': contract.get('natspec-user')
+            },
+        }
+        for contract_name, contract
+        in sorted_contracts
+    }

--- a/populus/solidity.py
+++ b/populus/solidity.py
@@ -1,0 +1,38 @@
+import subprocess
+import itertools
+
+
+class CompileError(Exception):
+    pass
+
+
+SOLC_BINARY = 'solc'
+
+
+def solc(source=None, input_files=None, add_std=True, combined_json='json-abi,binary,sol-abi,natspec-dev,natspec-user'):
+
+    if source and input_files:
+        raise ValueError("`source` and `input_files` are mutually exclusive")
+    elif source is None and input_files is None:
+        raise ValueError("Must provide either `source` or `input_files`")
+
+    command = ['solc']
+    if add_std:
+        command.append('--add-std=1')
+
+    if combined_json:
+        command.extend(('--combined-json', combined_json))
+
+    if input_files:
+        command.extend(itertools.chain(*zip(itertools.repeat('--input-file'), input_files)))
+
+    p = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+
+    if source:
+        stdoutdata, stderrdata = p.communicate(input=source)
+    else:
+        stdoutdata, stderrdata = p.communicate()
+
+    if p.returncode:
+        raise CompileError('compilation failed')
+    return stdoutdata

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click>=5.0
-ethereum-rpc-client==0.1.2
+ethereum-rpc-client>=0.1.2
 ethereum>=0.9.73
 https://github.com/ethereum/ethash/archive/v23.1.tar.gz
 eth-testrpc>=0.1.16

--- a/tests/command_line_interface/test_compilation.py
+++ b/tests/command_line_interface/test_compilation.py
@@ -2,12 +2,11 @@ import pytest
 import click
 from click.testing import CliRunner
 
-from ethereum._solidity import get_solidity
-
 from populus.cli import main
+from populus.solidity import is_solc_available
 
 skip_if_no_sol_compiler = pytest.mark.skipif(
-    get_solidity() is None,
+    is_solc_available() is None,
     reason="'solc' compiler not available",
 )
 

--- a/tests/command_line_interface/test_compilation.py
+++ b/tests/command_line_interface/test_compilation.py
@@ -6,7 +6,7 @@ from populus.cli import main
 from populus.solidity import is_solc_available
 
 skip_if_no_sol_compiler = pytest.mark.skipif(
-    is_solc_available() is None,
+    not is_solc_available(),
     reason="'solc' compiler not available",
 )
 

--- a/tests/compile/test_get_compiler_for_file.py
+++ b/tests/compile/test_get_compiler_for_file.py
@@ -1,7 +1,10 @@
 import pytest
 from populus.compilation import get_compiler_for_file
 
-from ethereum._solidity import get_solidity
+from populus.solidity import (
+    solc,
+    is_solc_available,
+)
 
 
 @pytest.mark.parametrize('filename', ['unknown.txt', 'unknown.bak', 'swap.sol.swp'])
@@ -10,13 +13,13 @@ def test_unknown_contract_extensions(filename):
         get_compiler_for_file(filename)
 
 
-@pytest.mark.skipif(get_solidity() is None, reason="'solc' compiler not available")
+@pytest.mark.skipif(is_solc_available() is None, reason="'solc' compiler not available")
 def test_solidity_compiler():
     compiler = get_compiler_for_file('Example.sol')
-    assert compiler == get_solidity()
+    assert compiler == solc
 
 
-@pytest.mark.skipif(get_solidity() is not None, reason="'solc' compiler available")
+@pytest.mark.skipif(is_solc_available() is not None, reason="'solc' compiler available")
 def test_solidity_compiler_not_available():
     with pytest.raises(ValueError):
         get_compiler_for_file('Example.sol')

--- a/tests/solidity/projects/test-01/contracts/Example.sol
+++ b/tests/solidity/projects/test-01/contracts/Example.sol
@@ -1,0 +1,4 @@
+contract Example {
+    function Example() {
+    }
+}

--- a/tests/solidity/test_solc.py
+++ b/tests/solidity/test_solc.py
@@ -7,7 +7,7 @@ from populus.solidity import (
 )
 
 skip_if_no_sol_compiler = pytest.mark.skipif(
-    is_solc_available() is None,
+    not is_solc_available(),
     reason="'solc' compiler not available",
 )
 

--- a/tests/solidity/test_solc.py
+++ b/tests/solidity/test_solc.py
@@ -3,6 +3,12 @@ import pytest
 from populus.solidity import (
     solc,
     version_regex,
+    is_solc_available,
+)
+
+skip_if_no_sol_compiler = pytest.mark.skipif(
+    is_solc_available() is None,
+    reason="'solc' compiler not available",
 )
 
 
@@ -23,21 +29,25 @@ def test_one_of_source_or_input_files_required():
         solc()
 
 
+@skip_if_no_sol_compiler
 def test_raw_source_compilation():
     code = solc(source=contract_source, raw=True)
     assert code == contract_compiled_raw
 
 
+@skip_if_no_sol_compiler
 def test_raw_file_compilation():
     code = solc(input_files=["tests/solidity/projects/test-01/contracts/Example.sol"], raw=True)
     assert code == contract_compiled_raw
 
 
+@skip_if_no_sol_compiler
 def test_json_source_compilation_not_rich():
     code = solc(source=contract_source, rich=False)
     assert code == contract_compiled_json
 
 
+@skip_if_no_sol_compiler
 def test_json_source_compilation():
     code = solc(source=contract_source, rich=False)
     assert code == contract_compiled_json

--- a/tests/solidity/test_solc.py
+++ b/tests/solidity/test_solc.py
@@ -1,0 +1,27 @@
+import pytest
+
+from populus.solidity import solc
+
+
+contract_source = "contract Example { function Example() {}}"
+contract_compiled_output = '{"contracts":{"Example":{"binary":"60606040525b5b600a8060136000396000f30060606040526008565b00","json-abi":"[{\\"inputs\\":[],\\"type\\":\\"constructor\\"}]\\n","natspec-dev":"{\\n   \\"methods\\" : {}\\n}\\n","natspec-user":"{\\n   \\"methods\\" : {}\\n}\\n","sol-abi":"contract Example{function Example();}"}}}\n\n'  # NOQA
+
+
+def test_source_and_input_files_mutually_exclusive():
+    with pytest.raises(ValueError):
+        solc(source=contract_source, input_files=['someContract.sol'])
+
+
+def test_one_of_source_or_input_files_required():
+    with pytest.raises(ValueError):
+        solc()
+
+
+def test_source_compilation():
+    code = solc(source=contract_source)
+    assert code == contract_compiled_output
+
+
+def test_file_compilation():
+    code = solc(input_files=["tests/solidity/projects/test-01/contracts/Example.sol"])
+    assert code == contract_compiled_output

--- a/tests/solidity/test_solc.py
+++ b/tests/solidity/test_solc.py
@@ -1,10 +1,16 @@
 import pytest
 
-from populus.solidity import solc
+from populus.solidity import (
+    solc,
+    version_regex,
+)
 
 
 contract_source = "contract Example { function Example() {}}"
-contract_compiled_output = '{"contracts":{"Example":{"binary":"60606040525b5b600a8060136000396000f30060606040526008565b00","json-abi":"[{\\"inputs\\":[],\\"type\\":\\"constructor\\"}]\\n","natspec-dev":"{\\n   \\"methods\\" : {}\\n}\\n","natspec-user":"{\\n   \\"methods\\" : {}\\n}\\n","sol-abi":"contract Example{function Example();}"}}}\n\n'  # NOQA
+contract_compiled_raw = '{"contracts":{"Example":{"binary":"60606040525b5b600a8060136000396000f30060606040526008565b00","json-abi":"[{\\"inputs\\":[],\\"type\\":\\"constructor\\"}]\\n","natspec-dev":"{\\n   \\"methods\\" : {}\\n}\\n","natspec-user":"{\\n   \\"methods\\" : {}\\n}\\n","sol-abi":"contract Example{function Example();}"}}}\n\n'  # NOQA
+contract_compiled_json = [('Example', {'natspec-user': {'methods': {}}, 'binary': '60606040525b5b600a8060136000396000f30060606040526008565b00', 'json-abi': [{'inputs': [], 'type': 'constructor'}], 'sol-abi': 'contract Example{function Example();}', 'natspec-dev': {'methods': {}}})]
+contract_compiled_json_rich = {'Example': {'natspec-user': {'methods': {}}, 'binary': '60606040525b5b600a8060136000396000f30060606040526008565b00', 'json-abi': [{'inputs': [], 'type': 'constructor'}], 'sol-abi': 'contract Example{function Example();}', 'natspec-dev': {'methods': {}}}}
+
 
 
 def test_source_and_input_files_mutually_exclusive():
@@ -17,11 +23,33 @@ def test_one_of_source_or_input_files_required():
         solc()
 
 
-def test_source_compilation():
-    code = solc(source=contract_source)
-    assert code == contract_compiled_output
+def test_raw_source_compilation():
+    code = solc(source=contract_source, raw=True)
+    assert code == contract_compiled_raw
 
 
-def test_file_compilation():
-    code = solc(input_files=["tests/solidity/projects/test-01/contracts/Example.sol"])
-    assert code == contract_compiled_output
+def test_raw_file_compilation():
+    code = solc(input_files=["tests/solidity/projects/test-01/contracts/Example.sol"], raw=True)
+    assert code == contract_compiled_raw
+
+
+def test_json_source_compilation_not_rich():
+    code = solc(source=contract_source, rich=False)
+    assert code == contract_compiled_json
+
+
+def test_json_source_compilation():
+    code = solc(source=contract_source, rich=False)
+    assert code == contract_compiled_json
+
+
+def test_version_with_hash():
+    version_string = 'solc, the solidity compiler commandline interface\nVersion: 0.1.1-054b3c3c/Release-Darwin/clang/JIT\n'
+    version = version_regex.search(version_string).groups()[0]
+    assert version == '0.1.1-054b3c3c'
+
+
+def test_version_without_hash():
+    version_string = 'solc, the solidity compiler commandline interface\nVersion: 0.1.1/Release-Darwin/clang/JIT\n'
+    version = version_regex.search(version_string).groups()[0]
+    assert version == '0.1.1'


### PR DESCRIPTION
Instead of relying on the solidity compiler provided by the `pyethereum` library, lets use our own.  This is going to let `populus` have much better control over contract compilation.

#### Cute animal picture.

![tumblr_m0je4ymlga1r3n418o1_400](https://cloud.githubusercontent.com/assets/824194/9426744/842cb86e-4911-11e5-80e9-f340e6f3b26e.jpg)
