### PR TITLE
support passing in 0x prefixed addresses as contract arguments

### DIFF
--- a/tests/contracts/test_function_object.py
+++ b/tests/contracts/test_function_object.py
@@ -31,3 +31,16 @@ def test_signature_single_arg():
 def test_signature_multiple_args():
     func = Function("multiply", [{'type': 'int256', 'name': 'a'}, {'type': 'int256', 'name': 'b'}])
     assert str(func) == "multiply(int256 a, int256 b)"
+
+
+def test_abi_args_signature(eth_coinbase):
+    func = Function("multiply", [{'type': 'address', 'name': 'to'}, {'type': 'uint256', 'name': 'deposit'}])
+    args_signature = func.abi_args_signature((eth_coinbase, 12345))
+    assert args_signature == '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x82\xa9x\xb3\xf5\x96*[\tW\xd9\xee\x9e\xefG.\xe5[B\xf1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0009'
+
+
+def test_abi_args_signature_with_0x_prefixed_address(eth_coinbase):
+    func = Function("multiply", [{'type': 'address', 'name': 'to'}, {'type': 'uint256', 'name': 'deposit'}])
+    prefixed_eth_coinbase = '0x' + eth_coinbase
+    args_signature = func.abi_args_signature((prefixed_eth_coinbase, 12345))
+    assert args_signature == '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x82\xa9x\xb3\xf5\x96*[\tW\xd9\xee\x9e\xefG.\xe5[B\xf1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0009'


### PR DESCRIPTION
Contract functions which take `address` types did not support passing in addresses with a `0x` prefix.  This was annoying.  This adds support for either format.

![12636showing](https://cloud.githubusercontent.com/assets/824194/9496446/9ba0cb3e-4bcd-11e5-803e-9e82eae492d2.jpg)
