### PR TITLE
Add file based logging to geth node runs

### DIFF
--- a/populus/cli.py
+++ b/populus/cli.py
@@ -29,6 +29,7 @@ from populus.web import (
 )
 from populus.geth import (
     get_geth_data_dir,
+    get_geth_logfile_path,
     run_geth_node,
     ensure_account_exists,
     reset_chain,
@@ -279,18 +280,11 @@ def chain_run(name, mine):
     Run a geth node.
     """
     data_dir = get_geth_data_dir(os.getcwd(), name)
-
-    if not os.path.exists(data_dir):
-        if name == 'default':
-            utils.ensure_path_exists(data_dir)
-        elif click.confirm("The chain '{0}' does not exist.  Would you like to create it?".format(name)):  # NOQA
-            utils.ensure_path_exists(data_dir)
-        else:
-            raise click.UsageError("Unknown chain '{0}'".format(name))
+    logfile_path = get_geth_logfile_path(data_dir)
 
     ensure_account_exists(data_dir)
 
-    command, proc = run_geth_node(data_dir, mine=mine)
+    command, proc = run_geth_node(data_dir, mine=mine, logfile=logfile_path)
 
     click.echo("Running: '{0}'".format(' '.join(command)))
 

--- a/populus/plugin.py
+++ b/populus/plugin.py
@@ -108,6 +108,7 @@ def geth_node(request):
     from populus.geth import (
         run_geth_node,
         get_geth_data_dir,
+        get_geth_logfile_path,
         ensure_account_exists,
         reset_chain,
     )
@@ -120,6 +121,9 @@ def geth_node(request):
     chain_name = getattr(request.module, 'geth_chain_name', 'default-test')
     data_dir = get_geth_data_dir(project_dir, chain_name)
 
+    logfile_name_fmt = "geth-{0}-{{0}}.log".format(request.module.__name__)
+    logfile_path = get_geth_logfile_path(data_dir, logfile_name_fmt)
+
     ensure_path_exists(data_dir)
     ensure_account_exists(data_dir)
 
@@ -131,7 +135,9 @@ def geth_node(request):
 
     geth_max_wait = getattr(request.module, 'geth_max_wait', 5)
 
-    command, proc = run_geth_node(data_dir, rpc_addr=rpc_host, rpc_port=rpc_port)
+    command, proc = run_geth_node(data_dir, rpc_addr=rpc_host,
+                                  rpc_port=rpc_port, logfile=logfile_path,
+                                  verbosity="6")
 
     start = time.time()
     while time.time() < start + geth_max_wait:


### PR DESCRIPTION
Adds logging of the output from `geth` nodes to a `logs` directory within the chain's data dir.

![54009904613f0 image](https://cloud.githubusercontent.com/assets/824194/9825283/7738f5b8-588f-11e5-922a-e4a78ee861e8.jpg)
