### PR TITLE
Fixed a minor issue with the sendTransaction method of a contract fun…

### DIFF
--- a/populus/contracts/functions.py
+++ b/populus/contracts/functions.py
@@ -65,9 +65,9 @@ class Function(ContractBound):
             # the transaction gets processed, the gas value we send
             # is still less than the gasLimit value when our transaction
             # eventually gets processed.
-            gasLimitFraction = 0.9
+            GAS_LIMIT_FRACTION = 0.9
             kwargs['gas'] = int(
-                gasLimitFraction * self.contract._meta.blockchain_client.get_max_gas()
+                GAS_LIMIT_FRACTION * self.contract._meta.blockchain_client.get_max_gas()
             )
 
         return self.contract._meta.blockchain_client.send_transaction(

--- a/populus/contracts/functions.py
+++ b/populus/contracts/functions.py
@@ -6,6 +6,7 @@ from populus.contracts.utils import (
     clean_args,
 )
 
+GAS_LIMIT_FRACTION = 0.9
 
 class Function(ContractBound):
     def __init__(self, name, inputs=None, outputs=None, constant=False):
@@ -65,7 +66,6 @@ class Function(ContractBound):
             # the transaction gets processed, the gas value we send
             # is still less than the gasLimit value when our transaction
             # eventually gets processed.
-            GAS_LIMIT_FRACTION = 0.9
             kwargs['gas'] = int(
                 GAS_LIMIT_FRACTION * self.contract._meta.blockchain_client.get_max_gas()
             )

--- a/populus/contracts/functions.py
+++ b/populus/contracts/functions.py
@@ -59,7 +59,16 @@ class Function(ContractBound):
         data = self.get_call_data(args)
 
         if 'gas' not in kwargs:
-            kwargs['gas'] = self.contract._meta.blockchain_client.get_max_gas()
+            # The gasLimit value on the geth chain seems to continuously
+            # decline after every block. We use a value of gas 
+            # slightly less than the get_max_gas value so that when 
+            # the transaction gets processed, the gas value we send 
+            # is still less than the gasLimit value when our transaction 
+            # eventually gets processed. 
+            gasLimitFraction = 0.9
+            kwargs['gas'] = int(
+                gasLimitFraction * self.contract._meta.blockchain_client.get_max_gas()
+	    )
 
         return self.contract._meta.blockchain_client.send_transaction(
             to=self.contract._meta.address,

--- a/populus/contracts/functions.py
+++ b/populus/contracts/functions.py
@@ -8,6 +8,7 @@ from populus.contracts.utils import (
 
 GAS_LIMIT_FRACTION = 0.9
 
+
 class Function(ContractBound):
     def __init__(self, name, inputs=None, outputs=None, constant=False):
         self.name = name

--- a/populus/contracts/functions.py
+++ b/populus/contracts/functions.py
@@ -60,11 +60,11 @@ class Function(ContractBound):
 
         if 'gas' not in kwargs:
             # The gasLimit value on the geth chain seems to continuously
-            # decline after every block. We use a value of gas 
-            # slightly less than the get_max_gas value so that when 
-            # the transaction gets processed, the gas value we send 
-            # is still less than the gasLimit value when our transaction 
-            # eventually gets processed. 
+            # decline after every block. We use a value of gas
+            # slightly less than the get_max_gas value so that when
+            # the transaction gets processed, the gas value we send
+            # is still less than the gasLimit value when our transaction
+            # eventually gets processed.
             gasLimitFraction = 0.9
             kwargs['gas'] = int(
                 gasLimitFraction * self.contract._meta.blockchain_client.get_max_gas()


### PR DESCRIPTION
…ction. The gas parameter of the transaction was being set too high and causing it to exceed the gasLimit value on the geth chain which caused the transaction to sit in pending transactions forever