### PR TITLE
Added a new feature that keeps track of known contracts

### DIFF
--- a/populus/cli/attach_cmd.py
+++ b/populus/cli/attach_cmd.py
@@ -21,15 +21,14 @@ from populus.contracts import (
     package_contracts,
 )
 from populus.geth import (
-    get_geth_data_dir,
+    get_active_data_dir,
     get_known_contracts,
 )
 
 from .main import main
 
 
-def setup_known_instances(context, name):
-    data_dir = get_geth_data_dir(os.getcwd(), name)
+def setup_known_instances(context, data_dir):
     # Attempt to load known contracts.
     knownCts = get_known_contracts(data_dir)
     for name in knownCts.keys():
@@ -65,24 +64,15 @@ def setup_known_instances(context, name):
 
 @main.command()
 @click.option(
-    '--knownfrom',
-    type=str,
-    default=None,
+    '--active/--no-active',
+    default=True,
     help=(
-        "Name of the test chain that we are attaching to. This is an "
-        "optional argument that can be used to help populate the "
-        "user environment with contracts recorded by the `deploy` "
-        "sub-command. This options is primarily intended to be "
-        "used with test chains when using the populus workflow. If "
-        "the passed chain has known contracts, it will "
-        "select all known contracts for each contract type and confirm "
-        "that the were deployed with latest contract code. These valid "
-        "addresses will be sorted by latest time stamp, and then added "
-        "as instances of their particular contract type into a list "
-        "on the member attribute 'known' on that contract class."
+        "This flag indicates whether the attach command will use "
+        "the chain that is referenced from the <proj>/chains/.active-chain "
+        "to load information about known contracts or not."
     ),
 )
-def attach(knownfrom):
+def attach(active):
     """
     Enter a python shell with contracts and blockchain client
     available.
@@ -94,9 +84,9 @@ def attach(knownfrom):
         'contracts': package_contracts(contracts_meta),
         'client': Client('127.0.0.1', '8545'),
     }
-
-    if knownfrom is not None:
-        setup_known_instances(context, knownfrom)
+    if active:
+        data_dir = get_active_data_dir(project_dir)
+        setup_known_instances(context, data_dir)
 
     contract_names = ', '.join(sorted(contracts_meta.keys()))
 

--- a/populus/cli/attach_cmd.py
+++ b/populus/cli/attach_cmd.py
@@ -47,13 +47,10 @@ def deploy_set(context, client, project_dir, data_dir=None, record=True, contrac
             will be interrogated to determine the contracts that
             can be deployed
         @param data_dir directory of the test chain if not None
-        @param contracts_by_name if not None, this must be a list
-            of strings indicating the names of the contracts to deploy
+        @param contracts_by_name Optional argument, this must be an
+            iterable of strings indicating the names of the contracts
+            to deploy. An empty list deploys all the contracts.
     """
-
-    if type(contracts_by_name) is not list:
-        raise TypeError("Contracts by name must be a list of strings")
-
     contracts = package_contracts(utils.load_contracts(project_dir))
     deployed_contracts = deploy_contracts(
         deploy_client=client,
@@ -81,10 +78,10 @@ def deploy_set(context, client, project_dir, data_dir=None, record=True, contrac
 
 def setup_known_instances(context, data_dir):
     # Attempt to load known contracts.
-    knownCts = get_known_contracts(data_dir)
-    for name, ctType in context["contracts"]:
-        if name in knownCts.keys():
-            addrList = knownCts[name]
+    known_cts = get_known_contracts(data_dir)
+    for name, ct_type in context["contracts"]:
+        if name in known_cts.keys():
+            addr_list = known_cts[name]
             # Latest Instances contains a list of the deployed contracts
             # for which the code matches with the current project
             # context's contract code. We use a sha512 hash to compare
@@ -92,22 +89,22 @@ def setup_known_instances(context, data_dir):
             # user has updated their code but failed to redeploy, and
             # cases where new contract methods might attempt to be called
             # on old contract addresses
-            latestInstances = []
-            currCodeHash = hashlib.sha512(ctType._config.code).hexdigest()
-            for data in addrList:
-                if currCodeHash == data["codehash"]:
-                    inst = ctType(data["address"], context["client"])
+            latest_instances = []
+            curr_code_hash = hashlib.sha512(ct_type._config.code).hexdigest()
+            for data in addr_list:
+                if curr_code_hash == data["codehash"]:
+                    inst = ct_type(data["address"], context["client"])
                     ts = datetime.strptime(data["ts"], "%Y-%m-%dT%H:%M:%S.%f")
-                    latestInstances.append((ts, inst))
+                    latest_instances.append((ts, inst))
 
-            # Ok - latestInstances has all the instances of this
+            # Ok - latest_instances has all the instances of this
             # contract type whose code matches with what we expect
             # it to be. Now let's sort this list by the time
             # stamp
-            latestInstances.sort(key=lambda r: r[0])
-            setattr(ctType, "known", [x[1] for x in latestInstances])
+            latest_instances.sort(key=lambda r: r[0])
+            setattr(ct_type, "known", [x[1] for x in latest_instances])
         else:
-            setattr(ctType, "known", [])
+            setattr(ct_type, "known", [])
 
 
 class ActiveDataDirChangedEventHandler(FileSystemEventHandler):

--- a/populus/cli/attach_cmd.py
+++ b/populus/cli/attach_cmd.py
@@ -193,7 +193,7 @@ def attach(active):
 
         contracts  -> Contract classes
         client     -> Blockchain client ({client_type})
-        redeploy   -> Method to reploy project contracts
+        redeploy   -> Method to re-deploy project contracts
                       Example:
                         deployed_cts = redeploy()
                         deployed_cts = redeploy(record = False)

--- a/populus/cli/attach_cmd.py
+++ b/populus/cli/attach_cmd.py
@@ -23,9 +23,57 @@ from populus.contracts import (
 from populus.geth import (
     get_active_data_dir,
     get_known_contracts,
+    add_to_known_contracts,
+)
+from populus.deployment import (
+    deploy_contracts,
+    validate_deployed_contracts,
+)
+from populus.cli.deploy_cmd import (
+    echo_post_deploy_message
 )
 
 from .main import main
+
+
+def deploy_set(context, client, project_dir, data_dir=None, record=True, contracts_by_name=[]):
+    """ Re-Deploy a set of contracts by name or all contracts
+        @param context local context for the attach python interpreter.
+        @param client RPC client for accessing the ethereum chain
+        @param project_dir absolute file path of the project that
+            will be interrogated to determine the contracts that
+            can be deployed
+        @param data_dir directory of the test chain if not None
+        @param contracts_by_name if not None, this must be a list
+            of strings indicating the names of the contracts to deploy
+    """
+
+    if type(contracts_by_name) is not list:
+        raise TypeError("Contracts by name must be a list of strings")
+
+    contracts = package_contracts(utils.load_contracts(project_dir))
+    deployed_contracts = deploy_contracts(
+        deploy_client=client,
+        contracts=contracts,
+        deploy_at_block=1,
+        max_wait_for_deploy=120,
+        from_address=None,
+        max_wait=120,
+        contracts_to_deploy=contracts_by_name,
+        dependencies=None,
+        constructor_args=None,
+        deploy_gas=None,
+    )
+    validate_deployed_contracts(client, deployed_contracts)
+    echo_post_deploy_message(client, deployed_contracts)
+    if data_dir is not None and record:
+        add_to_known_contracts(deployed_contracts, data_dir)
+    # Update the attach shell's context with the latest contracts
+    # objects
+    context["contracts"] = contracts
+    if data_dir is not None:
+        setup_known_instances(context, data_dir)
+    return(deployed_contracts)
 
 
 def setup_known_instances(context, data_dir):
@@ -79,17 +127,27 @@ def attach(active):
     """
     project_dir = os.path.abspath(os.getcwd())
     contracts_meta = utils.load_contracts(project_dir)
+    client = Client('127.0.0.1', '8545')
 
     context = {
         'contracts': package_contracts(contracts_meta),
-        'client': Client('127.0.0.1', '8545'),
+        'client': client,
     }
+    data_dir = None
     if active:
         data_dir = get_active_data_dir(project_dir)
         if os.path.islink(data_dir):
             setup_known_instances(context, data_dir)
         else:
             click.echo(click.style("No Valid Active Chain Data Directory Found!", fg="red"))
+
+    def redeploy(contracts=[], record=True):
+        return(deploy_set(
+            context, client, project_dir, data_dir=data_dir,
+            record=record, contracts_by_name=contracts
+        ))
+
+    context["redeploy"] = redeploy
 
     contract_names = ', '.join(sorted(contracts_meta.keys()))
 
@@ -103,9 +161,15 @@ def attach(active):
 
         contracts  -> Contract classes
         client     -> Blockchain client ({client_type})
+        redeploy   -> Method to reploy project contracts
+                      Example:
+                        deployed_cts = redeploy()
+                        deployed_cts = redeploy(record = False)
+                        deployed_cts = redeploy(contracts = ["Example"])
 
         Contracts: {contracts}
         Check contracts.<type>.known for deployed contracts.
+
         """
     ).format(
         python_version=sys.version.partition('\n')[0],

--- a/populus/cli/attach_cmd.py
+++ b/populus/cli/attach_cmd.py
@@ -1,6 +1,8 @@
 import os
 import sys
 import textwrap
+import hashlib
+from datetime import datetime
 
 import click
 
@@ -18,12 +20,69 @@ from populus import utils
 from populus.contracts import (
     package_contracts,
 )
+from populus.geth import (
+    get_geth_data_dir,
+    get_known_contracts,
+)
 
 from .main import main
 
 
+def setup_known_instances(context, name):
+    data_dir = get_geth_data_dir(os.getcwd(), name)
+    # Attempt to load known contracts.
+    knownCts = get_known_contracts(data_dir)
+    for name in knownCts.keys():
+        addrList = knownCts[name]
+        # Latest Instances contains a list of the deployed contracts
+        # for which the code matches with the current project
+        # context's contract code. We use a sha512 hash to compare
+        # the code of each. The idea here is to catch cases where the
+        # user has updated their code but failed to redeploy, and
+        # cases where new contract methods might attempt to be called
+        # on old contract addresses
+        latestInstances = []
+        ctType = None
+        try:
+            ctType = getattr(context["contracts"], name)
+        except AttributeError:
+            click.echo("Failed to find contract `{0}` in project context: skipping".format(name))
+            continue
+        currCodeHash = hashlib.sha512(ctType._config.code).hexdigest()
+        for data in addrList:
+            if currCodeHash == data["codehash"]:
+                inst = ctType(data["address"], context["client"])
+                ts = datetime.strptime(data["ts"], "%Y-%m-%dT%H:%M:%S.%f")
+                latestInstances.append((ts, inst))
+
+        # Ok - latestInstances has all the instances of this
+        # contract type whose code matches with what we expect
+        # it to be. Now let's sort this list by the time
+        # stamp
+        latestInstances.sort(key=lambda r: r[0])
+        setattr(ctType, "known", [x[1] for x in latestInstances])
+
+
 @main.command()
-def attach():
+@click.option(
+    '--knownfrom',
+    type=str,
+    default=None,
+    help=(
+        "Name of the test chain that we are attaching to. This is an "
+        "optional argument that can be used to help populate the "
+        "user environment with contracts recorded by the `deploy` "
+        "sub-command. This options is primarily intended to be "
+        "used with test chains when using the populus workflow. If "
+        "the passed chain has known contracts, it will "
+        "select all known contracts for each contract type and confirm "
+        "that the were deployed with latest contract code. These valid "
+        "addresses will be sorted by latest time stamp, and then added "
+        "as instances of their particular contract type into a list "
+        "on the member attribute 'known' on that contract class."
+    ),
+)
+def attach(knownfrom):
     """
     Enter a python shell with contracts and blockchain client
     available.
@@ -35,6 +94,9 @@ def attach():
         'contracts': package_contracts(contracts_meta),
         'client': Client('127.0.0.1', '8545'),
     }
+
+    if knownfrom is not None:
+        setup_known_instances(context, knownfrom)
 
     contract_names = ', '.join(sorted(contracts_meta.keys()))
 
@@ -50,6 +112,7 @@ def attach():
         client     -> Blockchain client ({client_type})
 
         Contracts: {contracts}
+        Check contracts.<type>.known for deployed contracts.
         """
     ).format(
         python_version=sys.version.partition('\n')[0],

--- a/populus/cli/attach_cmd.py
+++ b/populus/cli/attach_cmd.py
@@ -86,7 +86,10 @@ def attach(active):
     }
     if active:
         data_dir = get_active_data_dir(project_dir)
-        setup_known_instances(context, data_dir)
+        if os.path.islink(data_dir):
+            setup_known_instances(context, data_dir)
+        else:
+            click.echo(click.style("No Valid Active Chain Data Directory Found!", fg="red"))
 
     contract_names = ', '.join(sorted(contracts_meta.keys()))
 

--- a/populus/cli/chain_cmd.py
+++ b/populus/cli/chain_cmd.py
@@ -11,6 +11,7 @@ from populus.geth import (
     run_geth_node,
     ensure_account_exists,
     reset_chain,
+    set_active_data_dir
 )
 
 from .main import main
@@ -45,11 +46,18 @@ def chain_reset(name, confirm):
     help="""
     Set verbosity of the logging output. Default is 5, Range is 0-6.
     """)
-def chain_run(name, mine, verbosity):
+@click.option(
+    '--active/--no-active', default=True,
+    help="""
+    Set whether the chain run will modify the active-chain settings.
+    Default is to modify the active-chain setting.
+    """)
+def chain_run(name, mine, verbosity, active):
     """
     Run a geth node.
     """
-    data_dir = get_geth_data_dir(os.getcwd(), name)
+    project_dir = os.getcwd()
+    data_dir = get_geth_data_dir(project_dir, name)
     logfile_path = get_geth_logfile_path(data_dir)
 
     ensure_account_exists(data_dir)
@@ -62,6 +70,9 @@ def chain_run(name, mine, verbosity):
     command, proc = run_geth_node(data_dir, mine=mine, **kwargs)
 
     click.echo("Running: '{0}'".format(' '.join(command)))
+
+    if active:
+        set_active_data_dir(project_dir, name)
 
     try:
         while True:

--- a/populus/geth.py
+++ b/populus/geth.py
@@ -19,6 +19,7 @@ is_nice_available = functools.partial(utils.is_executable_available, 'nice')
 
 POPULUS_DIR = os.path.abspath(os.path.dirname(__file__))
 KNOWN_CONTRACTS_FILE = "known_contracts.json"
+ACTIVE_CHAIN_SYMLINK = ".active-chain"
 
 
 def get_blockchains_dir(project_dir):
@@ -32,6 +33,27 @@ def get_geth_data_dir(project_dir, name):
     data_dir = os.path.abspath(os.path.join(blockchains_dir, name))
     utils.ensure_path_exists(data_dir)
     return data_dir
+
+
+def get_active_data_dir(project_dir):
+    """ Given a project directory, this function creates the
+        file path string for the active chain symlink.
+    """
+    bc_dir = get_blockchains_dir(project_dir)
+    active_dir = os.path.abspath(os.path.join(bc_dir, ACTIVE_CHAIN_SYMLINK))
+    return(active_dir)
+
+
+def set_active_data_dir(project_dir, name):
+    """ Set which ethereum chain directory is the
+        active chain. This basically just creates a new
+        symlink pointed at the active chain.
+    """
+    data_dir = get_geth_data_dir(project_dir, name)
+    active_dir = get_active_data_dir(project_dir)
+    if os.path.islink(active_dir):
+        os.unlink(active_dir)
+    os.symlink(data_dir, active_dir)
 
 
 def get_geth_logfile_path(data_dir, logfile_name_fmt="geth-{0}.log"):

--- a/populus/geth.py
+++ b/populus/geth.py
@@ -41,7 +41,7 @@ def get_active_data_dir(project_dir):
     """
     bc_dir = get_blockchains_dir(project_dir)
     active_dir = os.path.abspath(os.path.join(bc_dir, ACTIVE_CHAIN_SYMLINK))
-    return(active_dir)
+    return active_dir
 
 
 def set_active_data_dir(project_dir, name):

--- a/populus/observers.py
+++ b/populus/observers.py
@@ -20,6 +20,20 @@ from populus.compilation import (
     get_project_libraries_dir,
     get_compiled_contract_destination_path,
 )
+from populus.geth import (
+    get_blockchains_dir,
+)
+
+
+def get_active_dir_observer(project_dir, event_handler):
+    """ Setup a polling observer on the project's
+        blockchains directory. This directory contains the
+        .active-chain symlink which is watched for.
+    """
+    bchain = get_blockchains_dir(project_dir)
+    observer = PollingObserver()
+    observer.schedule(event_handler, bchain, recursive=False)
+    return observer
 
 
 class ContractSourceChangedEventHandler(FileSystemEventHandler):


### PR DESCRIPTION
When using the populus workflow, I find myself being in this position where I copy/pasta the address of the deployed contract over and over. This is particularly annoying for me because I don't use a mouse. 

This pull request has some code that stores the contract address for each deployed contract in a "known_contracts.json" file associated with the test chain it deployed to. This json file contains the address, timestamp, and the SHA-512 hash of the solidity binary code. When the user runs the attach sub-command, they can select the test chain that they want to run against, and then the code will look at the "known_contracts.json" file to figure out what instances of the deployed contracts to make available in the user environment. It compares the SHA-512 hash of the latest solidity binary code and only instantiates known contracts for which these hashes match. 

This is a WIP. The current implementation is not very user friendly. Basically, the way the code is structured, the "chain run" method is separate from the attach method. This means that the attach method does not know the details of what chain is running (this is obviously by design and mirrors the way geth works). But what this means is I need an additional piece of information when I run attach to get the known contracts of that test chain. 

I'm proposing that we add a new sub-command "console" which would take the same arguments as the "chain run" command, but would be an amalgam of the "chain run" and "attach" commands. It would launch the "chain run" command in the background and then launch the "attach" console with the data_dir from the "chain run" command to figure out the known contracts. The user would still be able to see the log of the geth miner process by using "tail -f ./chains/default/logs/geth*.log". 

![Armadillo](http://i.imgur.com/mVBDL8r.jpg)