### PR TITLE
Re-add missing compiled contracts for cli testS

### DIFF
--- a/tests/cli/projects/test-02/build/contracts.json
+++ b/tests/cli/projects/test-02/build/contracts.json
@@ -1,0 +1,19 @@
+{
+    "owned": {
+        "code": "0x60606040525b33600060006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908302179055505b600a80603e6000396000f30060606040526008565b00",
+        "info": {
+            "abiDefinition": [
+                {
+                    "inputs": [],
+                    "type": "constructor"
+                }
+            ],
+            "compilerVersion": "0.9.73",
+            "developerDoc": null,
+            "language": "Solidity",
+            "languageVersion": "0",
+            "source": "contract owned {\n        address owner;\n\n        function owned() {\n                owner = msg.sender;\n        }\n}\n",
+            "userDoc": null
+        }
+    }
+}

--- a/tests/cli/projects/test-03/build/contracts.json
+++ b/tests/cli/projects/test-03/build/contracts.json
@@ -1,0 +1,19 @@
+{
+    "owned": {
+        "code": "0x60606040525b33600060006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908302179055505b600a80603e6000396000f30060606040526008565b00",
+        "info": {
+            "abiDefinition": [
+                {
+                    "inputs": [],
+                    "type": "constructor"
+                }
+            ],
+            "compilerVersion": "0.9.73",
+            "developerDoc": null,
+            "language": "Solidity",
+            "languageVersion": "0",
+            "source": "contract owned {\n        address owner;\n\n        function owned() {\n                owner = msg.sender;\n        }\n}\n",
+            "userDoc": null
+        }
+    }
+}

--- a/tests/cli/projects/test-04/build/contracts.json
+++ b/tests/cli/projects/test-04/build/contracts.json
@@ -1,0 +1,19 @@
+{
+    "owned": {
+        "code": "0x60606040525b33600060006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908302179055505b600a80603e6000396000f30060606040526008565b00",
+        "info": {
+            "abiDefinition": [
+                {
+                    "inputs": [],
+                    "type": "constructor"
+                }
+            ],
+            "compilerVersion": "0.9.73",
+            "developerDoc": null,
+            "language": "Solidity",
+            "languageVersion": "0",
+            "source": "contract owned {\n        address owner;\n\n        function owned() {\n                owner = msg.sender;\n        }\n}\n",
+            "userDoc": null
+        }
+    }
+}


### PR DESCRIPTION
Fix a few tests that rely on the compiled contracts in test projects.