### PR TITLE
pass an explicit (short) ipcpath to geth because unix socket paths ne…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ pip-log.txt
 # Unit test / coverage reports
 .coverage
 .tox
+.cache
 nosetests.xml
 
 # Translations

--- a/populus/cli/init_cmd.py
+++ b/populus/cli/init_cmd.py
@@ -36,7 +36,7 @@ def init():
     example_tests_path = os.path.join(tests_dir, 'test_example.py')
     if not os.path.exists(example_tests_path):
         with open(example_tests_path, 'w') as example_tests_file:
-            example_tests_file.write('def test_it(deployed_contracts):\n    example = deployed_contracts.Example\n    assert example.address\n')  # NOQA
+            example_tests_file.write('def test_it(deployed_contracts):\n    example = deployed_contracts.Example\n    assert example._meta.address\n')  # NOQA
         click.echo("Created Example Tests: ./{0}".format(os.path.relpath(example_tests_path)))  # NOQA
 
     initialize_web_directories(project_dir)

--- a/populus/geth.py
+++ b/populus/geth.py
@@ -9,6 +9,7 @@ import os
 import re
 import subprocess
 import hashlib
+import tempfile
 
 from populus import utils
 
@@ -146,7 +147,7 @@ def geth_wrapper(data_dir, popen_class=subprocess.Popen, cmd="geth",
                  genesis_block=None, miner_threads='1', extra_args=None,
                  max_peers='0', network_id='123456', no_discover=True,
                  mine=False, nice=True, unlock='0', password=DEFAULT_PW_PATH,
-                 port=None, verbosity=None, logfile=None):
+                 port=None, verbosity=None, logfile=None, ipcpath=None):
     if nice and is_nice_available():
         command = ['nice', '-n', '20', cmd]
     else:
@@ -159,6 +160,9 @@ def geth_wrapper(data_dir, popen_class=subprocess.Popen, cmd="geth",
 
     if port is None:
         port = utils.get_open_port()
+    
+    if ipcpath is None:
+        ipcpath = tempfile.NamedTemporaryFile().name
 
     command.extend((
         '--genesis', genesis_block,
@@ -166,6 +170,7 @@ def geth_wrapper(data_dir, popen_class=subprocess.Popen, cmd="geth",
         '--maxpeers', max_peers,
         '--networkid', network_id,
         '--port', port,
+        '--ipcpath', ipcpath,
     ))
 
     if miner_threads is not None:

--- a/tests/cli/test_compilation.py
+++ b/tests/cli/test_compilation.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import click
 from click.testing import CliRunner
@@ -10,10 +11,12 @@ skip_if_no_sol_compiler = pytest.mark.skipif(
     reason="'solc' compiler not available",
 )
 
+this_dir = os.path.dirname(__file__)
+
 
 @skip_if_no_sol_compiler
 def test_compiling(monkeypatch):
-    monkeypatch.chdir('./tests/cli/projects/test-01/')
+    monkeypatch.chdir(os.path.join(this_dir, 'projects/test-01/'))
     runner = CliRunner()
     result = runner.invoke(main, ['compile'])
 
@@ -27,7 +30,7 @@ def test_compiling(monkeypatch):
 
 @skip_if_no_sol_compiler
 def test_compiling_with_specified_contract(monkeypatch):
-    monkeypatch.chdir('./tests/cli/projects/test-01/')
+    monkeypatch.chdir(os.path.join(this_dir, 'projects/test-01/'))
     runner = CliRunner()
     result = runner.invoke(main, ['compile', 'Mortal'])
 
@@ -42,7 +45,7 @@ def test_compiling_with_specified_contract(monkeypatch):
 @skip_if_no_sol_compiler
 @pytest.mark.parametrize('path', ('owned.sol', 'contracts/owned.sol'))
 def test_compiling_with_specified_file(monkeypatch, path):
-    monkeypatch.chdir('./tests/cli/projects/test-01/')
+    monkeypatch.chdir(os.path.join(this_dir, 'projects/test-01/'))
     runner = CliRunner()
     result = runner.invoke(main, ['compile', path])
 
@@ -64,7 +67,7 @@ def test_compiling_with_specified_file(monkeypatch, path):
     ),
 )
 def test_compiling_with_specified_file_and_contract(monkeypatch, path):
-    monkeypatch.chdir('./tests/cli/projects/test-01/')
+    monkeypatch.chdir(os.path.join(this_dir, 'projects/test-01/'))
     runner = CliRunner()
     result = runner.invoke(main, ['compile', path])
 

--- a/tests/cli/test_deployment.py
+++ b/tests/cli/test_deployment.py
@@ -1,3 +1,4 @@
+import os
 import re
 import click
 import pytest
@@ -14,10 +15,11 @@ skip_if_no_geth = pytest.mark.skipif(
     reason="'geth' not available",
 )
 
+this_dir = os.path.dirname(__file__)
 
 @skip_if_no_geth
 def test_deployment(monkeypatch):
-    monkeypatch.chdir('./tests/cli/projects/test-02/')
+    monkeypatch.chdir(os.path.join(this_dir, 'projects/test-02/'))
     runner = CliRunner()
     result = runner.invoke(main, ['deploy', '--no-confirm', 'owned'])
 

--- a/tests/contracts/test_contract_object.py
+++ b/tests/contracts/test_contract_object.py
@@ -13,6 +13,7 @@ from populus.utils import (
 )
 
 
+
 @pytest.fixture(autouse=True)
 def _rpc_server(testrpc_server):
     return testrpc_server

--- a/tests/geth/test_running_geth_node.py
+++ b/tests/geth/test_running_geth_node.py
@@ -54,7 +54,7 @@ def test_running_node_without_mining(project_test04, open_port):
     data_dir = get_geth_data_dir(project_test04, 'default')
 
     command, proc = run_geth_node(data_dir, rpc_port=open_port, mine=False)
-    time.sleep(2)
+    wait_for_popen(proc)
     rpc_client = Client('127.0.0.1', port=open_port)
     coinbase = rpc_client.get_coinbase()
     proc.send_signal(signal.SIGINT)
@@ -67,14 +67,14 @@ def test_running_node_and_mining(project_test04, open_port):
     data_dir = get_geth_data_dir(project_test04, 'default')
 
     command, proc = run_geth_node(data_dir, rpc_port=open_port, mine=True)
-    time.sleep(2)
+    wait_for_popen(proc)
     rpc_client = Client('127.0.0.1', port=open_port)
     block_num = rpc_client.get_block_number()
     start = time.time()
-    while time.time() < start + 10:
+    while rpc_client.get_block_number() <= block_num:
         time.sleep(0.2)
-        if rpc_client.get_block_number() > block_num:
-            break
+        if time.time() > start + 20:
+            raise Exception('Could not mine block within 20 seconds')
     assert block_num < rpc_client.get_block_number()
     proc.send_signal(signal.SIGINT)
     wait_for_popen(proc)

--- a/tests/solidity/test_solc.py
+++ b/tests/solidity/test_solc.py
@@ -1,5 +1,5 @@
+import os
 import pytest
-
 import json
 
 from populus.solidity import (
@@ -13,12 +13,12 @@ skip_if_no_sol_compiler = pytest.mark.skipif(
     reason="'solc' compiler not available",
 )
 
+this_dir = os.path.dirname(__file__)
 
 contract_source = "contract Example { function Example() {}}"
 contract_compiled_raw = '{"contracts":{"Example":{"abi":"[{\\"inputs\\":[],\\"type\\":\\"constructor\\"}]\\n","bin":"60606040525b5b600a8060126000396000f360606040526008565b00","bin-runtime":"60606040526008565b00","devdoc":"{\\n   \\"methods\\" : {}\\n}\\n","userdoc":"{\\n   \\"methods\\" : {}\\n}\\n"}},"version":"0.1.3-1736fe80/RelWithDebInfo-Darwin/unknown/JIT linked to libethereum-0.9.92-dcf2fd11/RelWithDebInfo-Darwin/unknown/JIT"}\n\n'  # NOQA
 contract_compiled_json = [('Example', {'bin': '60606040525b5b600a8060126000396000f360606040526008565b00', "bin-runtime": "60606040526008565b00", 'abi': [{'inputs': [], 'type': 'constructor'}], 'userdoc': {'methods': {}}, 'devdoc': {'methods': {}}})]  # NOQA
 contract_compiled_json_rich = {'Example': {'natspec-user': {'methods': {}}, 'binary': '60606040525b5b600a8060136000396000f30060606040526008565b00', 'json-abi': [{'inputs': [], 'type': 'constructor'}], 'sol-abi': 'contract Example{function Example();}', 'natspec-dev': {'methods': {}}}}
-
 
 
 def test_source_and_input_files_mutually_exclusive():
@@ -50,7 +50,8 @@ def test_raw_source_compilation():
 
 @skip_if_no_sol_compiler
 def test_raw_file_compilation():
-    code = solc(input_files=["tests/solidity/projects/test-01/contracts/Example.sol"], raw=True)
+    input_file = os.path.join(this_dir, "projects/test-01/contracts/Example.sol")
+    code = solc(input_files=[input_file], raw=True)
     cmp_compile_data(json.loads(code), json.loads(contract_compiled_raw))
 
 


### PR DESCRIPTION
…ed to be short. This should fix #69.

I tested this on linux (mint) - it should work on other os's as well as it uses tempfile.