### PR TITLE
Include info from the compiler in CompileError

### DIFF
--- a/populus/solidity.py
+++ b/populus/solidity.py
@@ -48,7 +48,8 @@ def solc(source=None, input_files=None, add_std=True,
     if optimize:
         command.append('--optimize')
 
-    p = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE)
 
     if source:
         stdoutdata, stderrdata = p.communicate(input=source)

--- a/populus/solidity.py
+++ b/populus/solidity.py
@@ -48,7 +48,7 @@ def solc(source=None, input_files=None, add_std=True,
     if optimize:
         command.append('--optimize')
 
-    p = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    p = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     if source:
         stdoutdata, stderrdata = p.communicate(input=source)
@@ -56,7 +56,7 @@ def solc(source=None, input_files=None, add_std=True,
         stdoutdata, stderrdata = p.communicate()
 
     if p.returncode:
-        raise CompileError('compilation failed')
+        raise CompileError('compilation failed: ' + stderrdata)
 
     if raw:
         return stdoutdata

--- a/tests/solidity/test_solc.py
+++ b/tests/solidity/test_solc.py
@@ -6,6 +6,7 @@ from populus.solidity import (
     solc,
     version_regex,
     is_solc_available,
+    CompileError,
 )
 
 skip_if_no_sol_compiler = pytest.mark.skipif(
@@ -69,6 +70,14 @@ def test_json_source_compilation():
     for left, right in zip(code, contract_compiled_json):
         assert left[0] == right[0]
         cmp_compile_data(left[1], right[1])
+
+
+@skip_if_no_sol_compiler
+def test_invalid_source_compilation():
+    with pytest.raises(CompileError) as exception:
+        solc(source=u'This is not a contract that compiles', rich=False)
+    expected_error_message = u'Error: Expected import directive or contract definition'
+    assert expected_error_message in str(exception)
 
 
 def test_version_with_hash():


### PR DESCRIPTION
A pipe for stderr was missing when calling the solc compiler with popen; I included the feedback from the compiler in the error message. I also added a test for it. No cute animals, sorry, hope this is useful anyway :-)