### PR TITLE
Add Python 3 compatiblity for get_call_data

### DIFF
--- a/populus/contracts/functions.py
+++ b/populus/contracts/functions.py
@@ -43,7 +43,7 @@ class Function(ContractBound):
         """
         prefix = self.encoded_abi_signature
         suffix = self.abi_args_signature(args)
-        data = "{0}{1}".format(prefix, suffix)
+        data = prefix + suffix
         return ethereum_utils.encode_hex(data)
 
     def __get__(self, obj, type=None):


### PR DESCRIPTION
### What was wrong?

Binary data was expanded to unicode strings before merging.

### How was it fixed?

Don't use string formatting when dealing with binary data.

#### Cute Animal Picture

![Mr. Mikko doing diving](http://i.imgur.com/wHJZbAD.jpg)

