### PR TITLE
Fix decode_multi for Python 3

### DIFF
--- a/populus/contracts/utils.py
+++ b/populus/contracts/utils.py
@@ -49,14 +49,14 @@ def decode_multi(types, outputs):
         binascii.a2b_hex(strip_0x_prefix(outputs)),
     )
     processed_res = [
-        "0x" + strip_0x_prefix(v) if t == "address" else v
+        b"0x" + strip_0x_prefix(v, starter=b'0x') if t == "address" else v
         for t, v in zip(types, res)
     ]
     return processed_res
 
 
-def strip_0x_prefix(value):
-    if value.startswith('0x'):
+def strip_0x_prefix(value, starter='0x'):
+    if value.startswith(starter):
         return value[2:]
     return value
 


### PR DESCRIPTION
### What was wrong?

decode_multi was mixing byte and unicode strings

### How was it fixed?

Allow strip function to customize starter argument, in this case allow it to be set to byte string.

#### Cute Animal Picture

![Catsy](http://i.imgur.com/zLpjxQx.jpg)

