### PR TITLE
CLI: Support -h as a shortcut for --help

### DIFF
--- a/populus/cli/main.py
+++ b/populus/cli/main.py
@@ -1,7 +1,13 @@
 import click
 
 
-@click.group()
+CONTEXT_SETTINGS = dict(
+    # Support -h as a shortcut for --help
+    help_option_names=['-h', '--help'],
+)
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
 def main():
     """
     Populus


### PR DESCRIPTION
### What was wrong?

```
$ populus -h
Error: no such option: -h
$ 
```

### How was it fixed?

```
$ populus -h
Usage: populus [OPTIONS] COMMAND [ARGS]...

  Populus

Options:
  -h, --help  Show this message and exit.

[…]
```

#### Cute Animal Picture

![cat requesting help](http://amazinganimalphotos.com/wp-content/uploads/2014/11/funny-cat-memes.jpg)

