### PR TITLE
Don't implicitly monkey patch gevent when importing populus package.

### DIFF
--- a/docs/populus.overview.rst
+++ b/docs/populus.overview.rst
@@ -2,6 +2,8 @@ Overview
 ========
 
 Populus is a framework for developing applications for Ethereum.
+It provides both command line application ``populus`` and Python
+libraries to deal with smart contracts.
 
 
 Installation

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -6,7 +6,13 @@ Usage
 Introduction
 ------------
 
-Populus provides `populus` command line command and `populus` package. Besides this, Populus exposes `py-solc <https://github.com/pipermerriam/py-solc>`__ and `py-geth <https://github.com/pipermerriam/py-geth>`__ packages.
+Populus provides `populus` command line command and `populus` package. Besides this, Populus interally uses and exposes
+
+* `web3.py <https://github.com/pipermerriam/web3.py>`__
+
+* `py-solc <https://github.com/pipermerriam/py-solc>`__
+
+* `py-geth <https://github.com/pipermerriam/py-geth>`__
 
 Project Layout
 --------------
@@ -91,3 +97,21 @@ your contract classes and an RPC client available in the local namespace.
     Contracts: Example, AnotherExample
 
     ... >
+
+Programmatic use
+----------------
+
+You can use and import Python modules from :py:mod:`populus` package.
+
+Gevent asynchronous event loop notice
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Populus and underlying libraries (py-geth, web3.py) use  `gevent <http://www.gevent.org/>`_. gevent is a coroutine -based Python networking library that uses greenlet to provide a high-level synchronous API on top of the libev event loop.
+
+Gevent monkey patches Python standard library. If you are using Populus and its networking facilities inside your own application, `you need to run monkey patch functionality as early as possible in your application <http://www.gevent.org/gevent.monkey.html>`_.
+
+Populus command line application does this in :py:mod:`populus.cli` module import.
+
+
+
+

--- a/populus/__init__.py
+++ b/populus/__init__.py
@@ -1,6 +1,3 @@
 import pkg_resources
 
-from gevent import monkey
-monkey.patch_all()
-
 __version__ = pkg_resources.get_distribution("populus").version

--- a/populus/cli/__init__.py
+++ b/populus/cli/__init__.py
@@ -1,3 +1,11 @@
+# Patch stdlib when using Populus.
+# This should happen only when we are using populus as
+# standanlone CLI application.
+# https://github.com/pipermerriam/populus/issues/117
+from gevent import monkey
+monkey.patch_all()
+
+
 from .main import main  # NOQA
 from .chain_cmd import chain  # NOQA
 from .compile_cmd import compile_contracts  # NOQA


### PR DESCRIPTION
### What was wrong?

#117 

### How was it fixed?

Move monkey patch to `cli` submodule `__init__`. It's not optimal, as if you import some cli stuff gevent gets sucked in. However one would need to remove `populus.cli.__init__` import aliasing and put all imports to `cli.main` main function to make sure gevent is run only when the command line is invoked.

#### Cute Animal Picture

![owly owl](http://i.imgur.com/BxNGXny.jpg)

