### PR TITLE
Piper/implement populus project object

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -11,6 +11,62 @@ Populus supports configuration via a configuration file.  By default, populus wi
 * ``/the-path-to/your-project-directory/populus.ini``
 * ``$HOME/populus.ini``
 
-In addition you can spe
-development.  These commands are accessed via ``$ populus web``
+A simple populus config file will look something like the following.
 
+
+.. code-block::
+
+    [populus]
+    default_chain=morden
+
+    [chain:morden]
+    provider=web3.providers.rpc.RPCProvider
+    port=8001
+
+
+This filed declares that when connecting to the morden test network populus
+should use the RPC provider (instead of the default IPC based provider), and
+that it should connect over port ``8001`` instead of the default ``8545``.
+
+
+Setting and Unsetting
+^^^^^^^^^^^^^^^^^^^^^
+
+The configuration file can be easily modified using the ``$ populus config``
+command.
+
+
+.. code-block::
+
+    $ populus config:set default_chain:mainnet
+    $ populus config:set project_dir:some/sub-directory
+    $ populus config
+    [populus]
+      default_chain = mainnet
+      project_dir = some/sub-dir
+
+    $ populus config:set --section chain:mainnet provider:web3.providers.rpc.RPCProvider
+    $ populus config:set --section chain:mainnet port:8001
+    $ populus config
+    [populus]
+      default_chain = mainnet
+      project_dir = some/sub-dir
+
+    [chain:mainnet]
+      provider = web3.providers.rpc.RPCProvider
+      port = 8001
+
+    $ populus config:unset project_dir
+    $ populus config
+    [populus]
+      default_chain = mainnet
+
+    [chain:mainnet]
+      provider = web3.providers.rpc.RPCProvider
+      port = 8001
+
+    $ populus config:unset --section chain:mainnet *
+    Are you sure you want to remove the entire 'chain:mainnet' section? [Y/n] Y
+    $ populus config
+    [populus]
+      default_chain = mainnet

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,0 +1,16 @@
+Configuration
+-------------
+
+.. contents:: :local:
+
+Introduction
+^^^^^^^^^^^^
+
+Populus supports configuration via a configuration file.  By default, populus will search the following paths for a file named ``populus.ini``
+
+* ``/the-path-to/your-project-directory/populus.ini``
+* ``$HOME/populus.ini``
+
+In addition you can spe
+development.  These commands are accessed via ``$ populus web``
+

--- a/populus/cli/__init__.py
+++ b/populus/cli/__init__.py
@@ -3,3 +3,4 @@ from .chain_cmd import chain  # NOQA
 from .compile_cmd import compile_contracts  # NOQA
 from .deploy_cmd import deploy  # NOQA
 from .init_cmd import init  # NOQA
+from .config_cmd import config  # NOQA

--- a/populus/cli/config_cmd.py
+++ b/populus/cli/config_cmd.py
@@ -1,0 +1,116 @@
+import click
+
+from .main import main
+
+
+def validate_key_value_pair(ctx, param, keys_and_values):
+    for key_and_value in keys_and_values:
+        try:
+            key, value = key_and_value.split(':')
+        except ValueError:
+            raise click.BadParameter(
+                "Values must be formatted as 'key:value'."
+            )
+    return keys_and_values
+
+
+@main.group(invoke_without_command=True)
+@click.pass_context
+def config(ctx):
+    """
+    Wrapper around `geth`.
+    """
+    if ctx.invoked_subcommand is None:
+        project = ctx.obj['PROJECT']
+        config = project.config
+
+        if not any(config.options(section) for section in config.sections()):
+            click.echo(
+                "No configuration values set.  Use `populus config set "
+                "some_key:a_value` to set configuration options."
+            )
+
+        for section in config.sections():
+            if not config.options(section):
+                # don't print empty sections
+                continue
+            click.echo("[{0}]".format(section))
+            for key in config.options(section):
+                click.echo("  {key} = {value}".format(
+                    key=key, value=config.get(section, key)
+                ))
+
+
+@config.command('set')
+@click.option(
+    '--section',
+    '-s',
+    default='populus',
+)
+@click.argument(
+    'keys_and_values',
+    nargs=-1,
+    callback=validate_key_value_pair,
+)
+@click.pass_context
+def config_set(ctx, section, keys_and_values):
+    """
+    Sets key/value pairs in the populus.ini configuration file. Values should
+    be formatted as 'key:value'.
+    """
+    project = ctx.obj['PROJECT']
+    config = project.config
+
+    if not config.has_section(section):
+        config.add_section(section)
+
+    for key_and_value in keys_and_values:
+        key, value = key_and_value.split(':')
+        config.set(section, key, value)
+
+    with open(ctx.obj['PRIMARY_CONFIG'], 'w') as config_file:
+        config.write(config_file)
+
+
+@config.command('unset')
+@click.option(
+    '--section',
+    '-s',
+    default='populus',
+)
+@click.option(
+    '--confirm/--no-confirm',
+    is_flag=True,
+    default=True,
+)
+@click.argument(
+    'keys',
+    nargs=-1,
+)
+@click.pass_context
+def config_unset(ctx, section, confirm, keys):
+    """
+    Deletes the provided keys from the configuration.  To delete an entire
+    section, pass in '*'
+    """
+    project = ctx.obj['PROJECT']
+    config = project.config
+
+    if not config.has_section(section):
+        if confirm:
+            confirm_msg = (
+                "Are you sure you want to delete the {0!r} section?".format(
+                    section
+                )
+            )
+            click.prompt(confirm_msg, abort=True)
+        ctx.abort("Unknown section: {0!r}".format(section))
+
+    if len(keys) == 1 and keys[0] == "*":
+        config.remove_section(section)
+    else:
+        for key in keys:
+            config.remove_option(section, key)
+
+    with open(ctx.obj['PRIMARY_CONFIG'], 'w') as config_file:
+        config.write(config_file)

--- a/populus/cli/config_cmd.py
+++ b/populus/cli/config_cmd.py
@@ -103,7 +103,8 @@ def config_unset(ctx, section, confirm, keys):
                     section
                 )
             )
-            click.prompt(confirm_msg, abort=True)
+            if not click.prompt(confirm_msg):
+                ctx.abort()
         ctx.abort("Unknown section: {0!r}".format(section))
 
     if len(keys) == 1 and keys[0] == "*":

--- a/populus/cli/main.py
+++ b/populus/cli/main.py
@@ -1,4 +1,14 @@
+import os
 import click
+
+from populus.utils.config import (
+    load_config,
+    get_config_paths,
+    PRIMARY_CONFIG_FILENAME,
+)
+from populus.project import (
+    Project,
+)
 
 
 CONTEXT_SETTINGS = dict(
@@ -8,8 +18,48 @@ CONTEXT_SETTINGS = dict(
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
-def main():
+@click.option(
+    '--project-dir',
+    '-p',
+    help=(
+        "Specify the root directory of the populus project.  Defaults to the "
+        "current working directory"
+    ),
+    type=click.Path(exists=True, file_okay=False),
+    default=os.getcwd,
+)
+@click.option(
+    '--config',
+    '-c',
+    help=(
+        "Specify a populus configuration file to be used.  No other "
+        "configuration files will be loaded"
+    ),
+    type=click.File(),
+    multiple=True,
+)
+@click.option(
+    '--chain',
+    '-b',
+    help=(
+        "Specifies that the project should be configured against a specific "
+        "chain.  'mainnet' and 'morden' can be used as pre-defined public "
+        "networks.  Other values should be predefined in your populus.ini"
+    ),
+)
+@click.pass_context
+def main(ctx, config, project_dir, chain):
     """
     Populus
     """
-    pass
+    if not config:
+        primary_config = os.path.join(project_dir, PRIMARY_CONFIG_FILENAME)
+        config = get_config_paths(project_dir)
+    else:
+        primary_config = config[0]
+
+    project = Project(load_config(config), chain=chain)
+
+    ctx.obj = {}
+    ctx.obj['PROJECT'] = project
+    ctx.obj['PRIMARY_CONFIG'] = primary_config

--- a/populus/compilation.py
+++ b/populus/compilation.py
@@ -3,7 +3,7 @@ import json
 
 from populus.utils.filesystem import (
     get_contracts_dir,
-    get_compiled_contracts_destination_path,
+    get_compiled_contracts_file_path,
     recursive_find_files,
 )
 from solc import (
@@ -20,7 +20,7 @@ def find_project_contracts(project_dir):
 
 
 def write_compiled_sources(project_dir, compiled_sources):
-    compiled_contract_path = get_compiled_contracts_destination_path(project_dir)
+    compiled_contract_path = get_compiled_contracts_file_path(project_dir)
 
     with open(compiled_contract_path, 'w') as outfile:
         outfile.write(

--- a/populus/project.py
+++ b/populus/project.py
@@ -18,6 +18,9 @@ from populus.utils.filesystem import (
 from populus.utils.module_loading import (
     import_string,
 )
+from populus.utils.contracts import (
+    package_contracts,
+)
 from populus.utils.config import (
     load_config,
     get_config_paths,
@@ -123,3 +126,7 @@ class Project(object):
 
         provider = ProviderClass(**provider_kwargs)
         return Web3(provider)
+
+    @property
+    def contract_factories(self):
+        return package_contracts(self.web3, self.compiled_contracts)

--- a/populus/project.py
+++ b/populus/project.py
@@ -37,16 +37,16 @@ class Project(object):
 
         self.config = config
 
-        if chain is None:
-            chain = self.config.get('populus', 'default_chain', fallback=None)
+        if chain is None and self.config.has_option('populus', 'default_chain'):
+            chain = self.config.get('populus', 'default_chain')
 
         self.chain = chain
 
     @property
     def project_dir(self):
-        try:
-            return self.config['populus']['project_dir']
-        except KeyError:
+        if self.config.has_option('populus', 'project_dir'):
+            return self.config.get('populus', 'project_dir')
+        else:
             return os.getcwd()
 
     @property

--- a/populus/project.py
+++ b/populus/project.py
@@ -67,3 +67,7 @@ class Project(object):
                 project_dir=self.project_dir,
             )
         return self._cached_compiled_contracts
+
+    @property
+    def web3(self):
+        assert False

--- a/populus/project.py
+++ b/populus/project.py
@@ -1,0 +1,38 @@
+import os
+
+from populus.utils.filesystem import (
+    get_contracts_dir,
+    get_build_dir,
+    get_compiled_contracts_file_path,
+    get_blockchains_dir,
+)
+
+
+class Project(object):
+    config = None
+
+    def __init__(self, config):
+        self.config = config
+
+    @property
+    def project_dir(self):
+        try:
+            return self.config['populus']['project_dir']
+        except KeyError:
+            return os.getcwd()
+
+    @property
+    def contracts_dir(self):
+        return get_contracts_dir(self.project_dir)
+
+    @property
+    def build_dir(self):
+        return get_build_dir(self.project_dir)
+
+    @property
+    def compiled_contracts_file_path(self):
+        return get_compiled_contracts_file_path(self.project_dir)
+
+    @property
+    def blockchains_dir(self):
+        return get_blockchains_dir(self.project_dir)

--- a/populus/project.py
+++ b/populus/project.py
@@ -1,4 +1,5 @@
 import os
+import hashlib
 
 from populus.utils.filesystem import (
     get_contracts_dir,
@@ -6,12 +7,23 @@ from populus.utils.filesystem import (
     get_compiled_contracts_file_path,
     get_blockchains_dir,
 )
+from populus.utils.config import (
+    load_config,
+    get_config_paths,
+)
+from populus.compilation import (
+    find_project_contracts,
+    compile_project_contracts,
+)
 
 
 class Project(object):
     config = None
 
-    def __init__(self, config):
+    def __init__(self, config=None):
+        if config is None:
+            config = load_config(get_config_paths(os.getcwd()))
+
         self.config = config
 
     @property
@@ -36,3 +48,22 @@ class Project(object):
     @property
     def blockchains_dir(self):
         return get_blockchains_dir(self.project_dir)
+
+    _cached_compiled_contracts_hash = None
+    _cached_compiled_contracts = None
+
+    @property
+    def compiled_contracts(self):
+        source_file_paths = find_project_contracts(self.project_dir)
+        source_hash = hashlib.md5(b''.join(
+            open(source_file_path, 'rb').read()
+            for source_file_path
+            in source_file_paths
+        )).hexdigest()
+
+        if self._cached_compiled_contracts_hash != source_hash:
+            self._cached_compiled_contracts_hash = source_hash
+            _, self._cached_compiled_contracts = compile_project_contracts(
+                project_dir=self.project_dir,
+            )
+        return self._cached_compiled_contracts

--- a/populus/utils/chain.py
+++ b/populus/utils/chain.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import datetime
 
 from .filesystem import (
@@ -33,6 +34,41 @@ def get_nodekey_path(data_dir):
 
 
 IPC_FILENAME = 'geth.ipc'
+
+
+def get_default_ipc_path(testnet=False):
+    if testnet:
+        testnet = "testnet"
+    else:
+        testnet = ""
+
+    if sys.platform == 'darwin':
+        return os.path.expanduser(os.path.join(
+            "~",
+            "Library",
+            "Ethereum",
+            testnet,
+            "geth.ipc",
+        ))
+    elif sys.platform.startswith('linux'):
+        return os.path.expanduser(os.path.join(
+            "~",
+            "ethereum",
+            testnet,
+            "geth.ipc",
+        ))
+    elif sys.platform == 'win32':
+        return os.path.expanduser(os.path.join(
+            "~",
+            "AppData",
+            "Roaming",
+            "Ethereum",
+        ))
+    else:
+        raise ValueError(
+            "Unsupported platform '{0}'.  Only darwin/linux2/win32 are "
+            "supported.  You must specify the ipc_path".format(sys.platform)
+        )
 
 
 def get_geth_ipc_path(data_dir):

--- a/populus/utils/config.py
+++ b/populus/utils/config.py
@@ -33,3 +33,7 @@ def load_config(config_file_paths):
     config.read(reversed(config_file_paths))
 
     return config
+
+
+class Config(object):
+    def __init__(self, overrides,

--- a/populus/utils/config.py
+++ b/populus/utils/config.py
@@ -1,0 +1,35 @@
+import os
+import itertools
+import configparser
+
+
+CONFIG_SEARCH_PATHS = [
+    os.path.expanduser('~'),
+]
+
+CONFIG_FILENAMES = [
+    'populus.ini',
+]
+
+
+"""
+[populus]
+project_dir=/a-path/
+"""
+
+
+def get_config_search_paths(project_dir, extra_paths=CONFIG_SEARCH_PATHS):
+    return tuple(itertools.product(CONFIG_SEARCH_PATHS, CONFIG_FILENAMES))
+
+
+def load_config(search_paths):
+    all_possible_config_paths = [
+        os.path.join(path, filename)
+        for path, filename
+        in itertools.product(search_paths, CONFIG_FILENAMES)
+        if os.path.exists(os.path.join(path, filename))
+    ]
+    config = configparser.ConfigParser()
+    config.read(reversed(all_possible_config_paths))
+
+    return config

--- a/populus/utils/config.py
+++ b/populus/utils/config.py
@@ -18,18 +18,18 @@ project_dir=/a-path/
 """
 
 
-def get_config_search_paths(project_dir, extra_paths=CONFIG_SEARCH_PATHS):
-    return tuple(itertools.product(CONFIG_SEARCH_PATHS, CONFIG_FILENAMES))
-
-
-def load_config(search_paths):
-    all_possible_config_paths = [
+def get_config_paths(project_dir, extra_paths=CONFIG_SEARCH_PATHS):
+    search_paths = [project_dir] + extra_paths
+    all_config_file_paths = [
         os.path.join(path, filename)
         for path, filename
         in itertools.product(search_paths, CONFIG_FILENAMES)
-        if os.path.exists(os.path.join(path, filename))
     ]
+    return all_config_file_paths
+
+
+def load_config(config_file_paths):
     config = configparser.ConfigParser()
-    config.read(reversed(all_possible_config_paths))
+    config.read(reversed(config_file_paths))
 
     return config

--- a/populus/utils/config.py
+++ b/populus/utils/config.py
@@ -1,21 +1,60 @@
 import os
+import copy
 import itertools
-import configparser
+
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
+
+from .chain import (
+    get_default_ipc_path,
+)
 
 
 CONFIG_SEARCH_PATHS = [
     os.path.expanduser('~'),
 ]
 
+PRIMARY_CONFIG_FILENAME = 'populus.ini'
 CONFIG_FILENAMES = [
-    'populus.ini',
+    PRIMARY_CONFIG_FILENAME,
 ]
 
 
-"""
-[populus]
-project_dir=/a-path/
-"""
+TEST_DEFAULTS = {
+    'provider': 'web3.providers.rpc.TestRPCProvider',
+}
+
+MAINNET_DEFAULTS = {
+    'provider': 'web3.providers.ipc.IPCProvider',
+    'ipc_path': get_default_ipc_path(testnet=False),
+}
+
+MORDEN_DEFAULTS = {
+    'provider': 'web3.providers.ipc.IPCProvider',
+    'ipc_path': get_default_ipc_path(testnet=True),
+}
+
+
+class Config(configparser.ConfigParser):
+    @property
+    def chains(self):
+        defaults = {
+            'mainnet': copy.deepcopy(MAINNET_DEFAULTS),
+            'morden': copy.deepcopy(MORDEN_DEFAULTS),
+            'test': copy.deepcopy(TEST_DEFAULTS),
+        }
+        declared_chains = {
+            section.partition(':')[2]: {
+                section_key: self.get(section, section_key)
+                for section_key in self.options(section)
+            }
+            for section in self.sections()
+            if section.startswith('chain:')
+        }
+        defaults.update(declared_chains)
+        return defaults
 
 
 def get_config_paths(project_dir, extra_paths=CONFIG_SEARCH_PATHS):
@@ -29,11 +68,7 @@ def get_config_paths(project_dir, extra_paths=CONFIG_SEARCH_PATHS):
 
 
 def load_config(config_file_paths):
-    config = configparser.ConfigParser()
+    config = Config()
     config.read(reversed(config_file_paths))
 
     return config
-
-
-class Config(object):
-    def __init__(self, overrides,

--- a/populus/utils/contracts.py
+++ b/populus/utils/contracts.py
@@ -17,7 +17,7 @@ from populus.utils.functional import (
     compose,
 )
 from .filesystem import (
-    get_compiled_contracts_destination_path,
+    get_compiled_contracts_file_path,
 )
 
 
@@ -47,7 +47,7 @@ def package_contracts(web3, contracts):
 
 
 def load_compiled_contract_json(project_dir):
-    compiled_contracts_path = get_compiled_contracts_destination_path(project_dir)
+    compiled_contracts_path = get_compiled_contracts_file_path(project_dir)
 
     if not os.path.exists(compiled_contracts_path):
         raise ValueError("No compiled contracts found")

--- a/populus/utils/filesystem.py
+++ b/populus/utils/filesystem.py
@@ -49,7 +49,7 @@ def get_build_dir(project_dir):
 COMPILED_CONTRACTS_FILENAME = "contracts.json"
 
 
-def get_compiled_contracts_destination_path(project_dir):
+def get_compiled_contracts_file_path(project_dir):
     build_dir = get_build_dir(project_dir)
     return os.path.join(build_dir, COMPILED_CONTRACTS_FILENAME)
 

--- a/populus/utils/module_loading.py
+++ b/populus/utils/module_loading.py
@@ -1,0 +1,24 @@
+from importlib import import_module
+
+
+def import_string(dotted_path):
+    """
+    Source: django.utils.module_loading
+
+    Import a dotted module path and return the attribute/class designated by the
+    last name in the path. Raise ImportError if the import failed.
+    """
+    try:
+        module_path, class_name = dotted_path.rsplit('.', 1)
+    except ValueError:
+        msg = "%s doesn't look like a module path" % dotted_path
+        raise ImportError(msg)
+
+    module = import_module(module_path)
+
+    try:
+        return getattr(module, class_name)
+    except AttributeError:
+        msg = 'Module "%s" does not define a "%s" attribute/class' % (
+            module_path, class_name)
+        raise ImportError(msg)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-norecursedirs='tests/*/projects'
+python_paths= .

--- a/tests/cli/test_config_setting_and_unsetting.py
+++ b/tests/cli/test_config_setting_and_unsetting.py
@@ -1,0 +1,128 @@
+import os
+import textwrap
+from click.testing import CliRunner
+
+from populus.utils.config import load_config
+
+from populus.cli import main
+
+
+def test_setting_with_no_config_file_lazily_creates_file(project_dir):
+    populus_ini_path = os.path.join(project_dir, 'populus.ini')
+
+    assert not os.path.exists(populus_ini_path)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ['config', 'set', 'default_chain:testnet'])
+
+    assert result.exit_code == 0, result.output + str(result.exception)
+
+    assert os.path.exists(populus_ini_path)
+
+    config = load_config([populus_ini_path])
+    assert config['populus']['default_chain'] == 'testnet'
+
+
+def test_setting_overwritting_value(project_dir, write_project_file):
+    ini_contents = textwrap.dedent(("""
+    [populus]
+    default_chain=mainnet
+    """).strip())
+    write_project_file('populus.ini', ini_contents)
+
+    populus_ini_path = os.path.join(project_dir, 'populus.ini')
+
+    config = load_config([populus_ini_path])
+    assert config['populus']['default_chain'] == 'mainnet'
+
+    runner = CliRunner()
+    result = runner.invoke(main, ['config', 'set', 'default_chain:testnet'])
+
+    assert result.exit_code == 0, result.output + str(result.exception)
+
+    config = load_config([populus_ini_path])
+    assert config['populus']['default_chain'] == 'testnet'
+
+
+def test_setting_non_default_section(project_dir, write_project_file):
+    ini_contents = textwrap.dedent(("""
+    [populus]
+    """).strip())
+    write_project_file('populus.ini', ini_contents)
+
+    populus_ini_path = os.path.join(project_dir, 'populus.ini')
+
+    config = load_config([populus_ini_path])
+    assert not config.has_section('chain:mainnet')
+
+    runner = CliRunner()
+    result = runner.invoke(main, ['config', 'set', '--section', 'chain:mainnet', 'provider:web3.providers.rpc.RPCProvider'])
+
+    assert result.exit_code == 0, result.output + str(result.exception)
+
+    config = load_config([populus_ini_path])
+    assert config.has_section('chain:mainnet')
+    assert config.chains['mainnet']['provider'] == 'web3.providers.rpc.RPCProvider'
+
+
+def test_unsetting_value(project_dir, write_project_file):
+    ini_contents = textwrap.dedent(("""
+    [populus]
+    default_chain=mainnet
+    """).strip())
+    write_project_file('populus.ini', ini_contents)
+
+    populus_ini_path = os.path.join(project_dir, 'populus.ini')
+
+    config = load_config([populus_ini_path])
+    assert 'default_chain' in config['populus']
+
+    runner = CliRunner()
+    result = runner.invoke(main, ['config', 'unset', 'default_chain'])
+
+    assert result.exit_code == 0, result.output + str(result.exception)
+
+    config = load_config([populus_ini_path])
+    assert 'default_chain' not in config['populus']
+
+
+def test_unsetting_value_that_is_not_present(project_dir, write_project_file):
+    ini_contents = textwrap.dedent(("""
+    [populus]
+    """).strip())
+    write_project_file('populus.ini', ini_contents)
+
+    populus_ini_path = os.path.join(project_dir, 'populus.ini')
+
+    config = load_config([populus_ini_path])
+    assert 'default_chain' not in config['populus']
+
+    runner = CliRunner()
+    result = runner.invoke(main, ['config', 'unset', 'default_chain'])
+
+    assert result.exit_code == 0, result.output + str(result.exception)
+
+    config = load_config([populus_ini_path])
+    assert 'default_chain' not in config['populus']
+
+
+def test_unsetting_entire_section(project_dir, write_project_file):
+    ini_contents = textwrap.dedent(("""
+    [populus]
+
+    [extra_section]
+    """).strip())
+    write_project_file('populus.ini', ini_contents)
+
+    populus_ini_path = os.path.join(project_dir, 'populus.ini')
+
+    config = load_config([populus_ini_path])
+    assert config.has_section('extra_section')
+
+    runner = CliRunner()
+    result = runner.invoke(main, ['config', 'unset', '--section', 'extra_section', '--no-confirm', '*'])
+
+    assert result.exit_code == 0, result.output + str(result.exception)
+
+    config = load_config([populus_ini_path])
+    assert not config.has_section('extra_section')

--- a/tests/cli/test_config_setting_and_unsetting.py
+++ b/tests/cli/test_config_setting_and_unsetting.py
@@ -20,20 +20,20 @@ def test_setting_with_no_config_file_lazily_creates_file(project_dir):
     assert os.path.exists(populus_ini_path)
 
     config = load_config([populus_ini_path])
-    assert config['populus']['default_chain'] == 'testnet'
+    assert config.get('populus', 'default_chain') == 'testnet'
 
 
 def test_setting_overwritting_value(project_dir, write_project_file):
-    ini_contents = textwrap.dedent(("""
-    [populus]
-    default_chain=mainnet
-    """).strip())
+    ini_contents = '\n'.join((
+        "[populus]",
+        "default_chain=mainnet",
+    )).format(project_dir=project_dir)
     write_project_file('populus.ini', ini_contents)
 
     populus_ini_path = os.path.join(project_dir, 'populus.ini')
 
     config = load_config([populus_ini_path])
-    assert config['populus']['default_chain'] == 'mainnet'
+    assert config.get('populus', 'default_chain') == 'mainnet'
 
     runner = CliRunner()
     result = runner.invoke(main, ['config', 'set', 'default_chain:testnet'])
@@ -41,13 +41,13 @@ def test_setting_overwritting_value(project_dir, write_project_file):
     assert result.exit_code == 0, result.output + str(result.exception)
 
     config = load_config([populus_ini_path])
-    assert config['populus']['default_chain'] == 'testnet'
+    assert config.get('populus', 'default_chain') == 'testnet'
 
 
 def test_setting_non_default_section(project_dir, write_project_file):
-    ini_contents = textwrap.dedent(("""
-    [populus]
-    """).strip())
+    ini_contents = '\n'.join((
+        "[populus]",
+    )).format(project_dir=project_dir)
     write_project_file('populus.ini', ini_contents)
 
     populus_ini_path = os.path.join(project_dir, 'populus.ini')
@@ -66,16 +66,16 @@ def test_setting_non_default_section(project_dir, write_project_file):
 
 
 def test_unsetting_value(project_dir, write_project_file):
-    ini_contents = textwrap.dedent(("""
-    [populus]
-    default_chain=mainnet
-    """).strip())
+    ini_contents = '\n'.join((
+        "[populus]",
+        "default_chain=mainnet",
+    )).format(project_dir=project_dir)
     write_project_file('populus.ini', ini_contents)
 
     populus_ini_path = os.path.join(project_dir, 'populus.ini')
 
     config = load_config([populus_ini_path])
-    assert 'default_chain' in config['populus']
+    assert config.has_option('populus', 'default_chain')
 
     runner = CliRunner()
     result = runner.invoke(main, ['config', 'unset', 'default_chain'])
@@ -83,19 +83,19 @@ def test_unsetting_value(project_dir, write_project_file):
     assert result.exit_code == 0, result.output + str(result.exception)
 
     config = load_config([populus_ini_path])
-    assert 'default_chain' not in config['populus']
+    assert not config.has_option('populus', 'default_chain')
 
 
 def test_unsetting_value_that_is_not_present(project_dir, write_project_file):
-    ini_contents = textwrap.dedent(("""
-    [populus]
-    """).strip())
+    ini_contents = '\n'.join((
+        "[populus]",
+    )).format(project_dir=project_dir)
     write_project_file('populus.ini', ini_contents)
 
     populus_ini_path = os.path.join(project_dir, 'populus.ini')
 
     config = load_config([populus_ini_path])
-    assert 'default_chain' not in config['populus']
+    assert not config.has_option('populus', 'default_chain')
 
     runner = CliRunner()
     result = runner.invoke(main, ['config', 'unset', 'default_chain'])
@@ -103,15 +103,15 @@ def test_unsetting_value_that_is_not_present(project_dir, write_project_file):
     assert result.exit_code == 0, result.output + str(result.exception)
 
     config = load_config([populus_ini_path])
-    assert 'default_chain' not in config['populus']
+    assert not config.has_option('populus', 'default_chain')
 
 
 def test_unsetting_entire_section(project_dir, write_project_file):
-    ini_contents = textwrap.dedent(("""
-    [populus]
-
-    [extra_section]
-    """).strip())
+    ini_contents = '\n'.join((
+        "[populus]",
+        "",
+        "[extra_section]",
+    )).format(project_dir=project_dir)
     write_project_file('populus.ini', ini_contents)
 
     populus_ini_path = os.path.join(project_dir, 'populus.ini')

--- a/tests/configuration/test_chain_configuration.py
+++ b/tests/configuration/test_chain_configuration.py
@@ -1,0 +1,22 @@
+import os
+import textwrap
+
+from populus.utils.config import (
+    get_config_paths,
+    load_config,
+)
+
+
+def test_default_chain_configuration(project_dir, write_project_file):
+    ini_contents = textwrap.dedent(("""
+    [populus]
+    project_dir={project_dir}
+
+    [chain:mainnet]
+    network_id = 1
+    """.format(project_dir=project_dir)).strip())
+    write_project_file('populus.ini', ini_contents)
+
+    config = load_config(get_config_paths(project_dir, []))
+
+    assert 'mainnet' in config.chains

--- a/tests/configuration/test_chain_configuration.py
+++ b/tests/configuration/test_chain_configuration.py
@@ -1,5 +1,4 @@
 import os
-import textwrap
 
 from populus.utils.config import (
     get_config_paths,
@@ -8,12 +7,13 @@ from populus.utils.config import (
 
 
 def test_chains_property(project_dir, write_project_file):
-    ini_contents = textwrap.dedent(("""
-    [populus]
-    project_dir={project_dir}
-
-    [chain:local]
-    """.format(project_dir=project_dir)).strip())
+    ini_contents = '\n'.join((
+        "[populus]",
+        "project_dir={project_dir}",
+        "",
+        "[chain:local]",
+        "provider=web3.providers.ipc.IPCProvider",
+    )).format(project_dir=project_dir)
     write_project_file('populus.ini', ini_contents)
 
     config = load_config(get_config_paths(project_dir, []))
@@ -43,13 +43,13 @@ def test_mainnet_chain_config_defaults(project_dir):
 
 
 def test_custom_declared_chain_configuration(project_dir, write_project_file):
-    ini_contents = textwrap.dedent(("""
-    [populus]
-    project_dir={project_dir}
-
-    [chain:mainnet]
-    provider = web3.providers.rpc.RPCProvider
-    """.format(project_dir=project_dir)).strip())
+    ini_contents = '\n'.join((
+        "[populus]",
+        "project_dir={project_dir}",
+        "",
+        "[chain:mainnet]",
+        "provider=web3.providers.rpc.RPCProvider",
+    )).format(project_dir=project_dir)
     write_project_file('populus.ini', ini_contents)
 
     config = load_config(get_config_paths(project_dir, []))

--- a/tests/configuration/test_chain_configuration.py
+++ b/tests/configuration/test_chain_configuration.py
@@ -7,16 +7,52 @@ from populus.utils.config import (
 )
 
 
-def test_default_chain_configuration(project_dir, write_project_file):
+def test_chains_property(project_dir, write_project_file):
     ini_contents = textwrap.dedent(("""
     [populus]
     project_dir={project_dir}
 
-    [chain:mainnet]
-    network_id = 1
+    [chain:local]
     """.format(project_dir=project_dir)).strip())
     write_project_file('populus.ini', ini_contents)
 
     config = load_config(get_config_paths(project_dir, []))
 
-    assert 'mainnet' in config.chains
+    assert 'local' in config.chains
+
+
+def test_testing_chain_config_defaults(project_dir):
+    config = load_config(get_config_paths(project_dir, []))
+
+    assert config.chains['test']['provider'] == 'web3.providers.rpc.TestRPCProvider'
+
+
+def test_morden_chain_config_defaults(project_dir):
+    config = load_config(get_config_paths(project_dir, []))
+
+    assert config.chains['morden']['provider'] == 'web3.providers.ipc.IPCProvider'
+    assert 'ipc_path' in config.chains['morden']
+    assert 'testnet' in config.chains['morden']['ipc_path']
+
+
+def test_mainnet_chain_config_defaults(project_dir):
+    config = load_config(get_config_paths(project_dir, []))
+
+    assert config.chains['mainnet']['provider'] == 'web3.providers.ipc.IPCProvider'
+    assert 'ipc_path' in config.chains['mainnet']
+
+
+def test_custom_declared_chain_configuration(project_dir, write_project_file):
+    ini_contents = textwrap.dedent(("""
+    [populus]
+    project_dir={project_dir}
+
+    [chain:mainnet]
+    provider = web3.providers.rpc.RPCProvider
+    """.format(project_dir=project_dir)).strip())
+    write_project_file('populus.ini', ini_contents)
+
+    config = load_config(get_config_paths(project_dir, []))
+
+    assert config.chains['mainnet']['provider'] == 'web3.providers.rpc.RPCProvider'
+    assert 'ipc_path' not in config.chains['mainnet']

--- a/tests/configuration/test_finding_configuration_file.py
+++ b/tests/configuration/test_finding_configuration_file.py
@@ -1,5 +1,4 @@
 import os
-import textwrap
 
 from populus.utils.config import (
     get_config_paths,
@@ -8,29 +7,29 @@ from populus.utils.config import (
 
 
 def test_loading_single_config_file(project_dir, write_project_file):
-    ini_contents = textwrap.dedent(("""
-    [populus]
-    project_dir={project_dir}
-    """.format(project_dir=project_dir)).strip())
+    ini_contents = '\n'.join((
+        "[populus]",
+        "project_dir={project_dir}",
+    )).format(project_dir=project_dir)
     write_project_file('populus.ini', ini_contents)
 
     config = load_config(get_config_paths(project_dir, []))
 
-    assert config['populus']['project_dir'] == project_dir
+    assert config.get('populus', 'project_dir') == project_dir
 
 
 def test_loading_multiple_config_files(project_dir, write_project_file):
-    primary_ini_contents = textwrap.dedent(("""
-    [populus]
-    project_dir={project_dir}
-    """.format(project_dir=project_dir)).strip())
+    primary_ini_contents = '\n'.join((
+        "[populus]",
+        "project_dir={project_dir}",
+    )).format(project_dir=project_dir)
 
     write_project_file('populus.ini', primary_ini_contents)
 
-    other_ini_contents = textwrap.dedent(("""
-    [populus]
-    project_dir=/should-not-override/
-    """.format(project_dir=project_dir)).strip())
+    other_ini_contents = '\n'.join((
+        "[populus]",
+        "project_dir=/should-not-override/",
+    )).format(project_dir=project_dir)
 
     write_project_file('./subdir/populus.ini', other_ini_contents)
 
@@ -40,4 +39,4 @@ def test_loading_multiple_config_files(project_dir, write_project_file):
         [os.path.join(project_dir, 'subdir')],
     ))
 
-    assert config['populus']['project_dir'] == project_dir
+    assert config.get('populus', 'project_dir') == project_dir

--- a/tests/configuration/test_finding_configuration_file.py
+++ b/tests/configuration/test_finding_configuration_file.py
@@ -2,7 +2,8 @@ import os
 import textwrap
 
 from populus.utils.config import (
-    get_config,
+    get_config_paths,
+    load_config,
 )
 
 
@@ -13,7 +14,7 @@ def test_loading_single_config_file(project_dir, write_project_file):
     """.format(project_dir=project_dir)).strip())
     write_project_file('populus.ini', ini_contents)
 
-    config = load_config(project_dir)
+    config = load_config(get_config_paths(project_dir, []))
 
     assert config['populus']['project_dir'] == project_dir
 
@@ -34,9 +35,9 @@ def test_loading_multiple_config_files(project_dir, write_project_file):
     write_project_file('./subdir/populus.ini', other_ini_contents)
 
 
-    config = load_config(
+    config = load_config(get_config_paths(
         project_dir,
-        os.path.join(project_dir, 'subdir'),
-    )
+        [os.path.join(project_dir, 'subdir')],
+    ))
 
     assert config['populus']['project_dir'] == project_dir

--- a/tests/configuration/test_finding_configuration_file.py
+++ b/tests/configuration/test_finding_configuration_file.py
@@ -1,0 +1,42 @@
+import os
+import textwrap
+
+from populus.utils.config import (
+    get_config,
+)
+
+
+def test_loading_single_config_file(project_dir, write_project_file):
+    ini_contents = textwrap.dedent(("""
+    [populus]
+    project_dir={project_dir}
+    """.format(project_dir=project_dir)).strip())
+    write_project_file('populus.ini', ini_contents)
+
+    config = load_config(project_dir)
+
+    assert config['populus']['project_dir'] == project_dir
+
+
+def test_loading_multiple_config_files(project_dir, write_project_file):
+    primary_ini_contents = textwrap.dedent(("""
+    [populus]
+    project_dir={project_dir}
+    """.format(project_dir=project_dir)).strip())
+
+    write_project_file('populus.ini', primary_ini_contents)
+
+    other_ini_contents = textwrap.dedent(("""
+    [populus]
+    project_dir=/should-not-override/
+    """.format(project_dir=project_dir)).strip())
+
+    write_project_file('./subdir/populus.ini', other_ini_contents)
+
+
+    config = load_config(
+        project_dir,
+        os.path.join(project_dir, 'subdir'),
+    )
+
+    assert config['populus']['project_dir'] == project_dir

--- a/tests/project/conftest.py
+++ b/tests/project/conftest.py
@@ -1,0 +1,81 @@
+import pytest
+import json
+import textwrap
+
+
+CONTRACT_MATH_CODE = "0x606060405261022e806100126000396000f360606040523615610074576000357c01000000000000000000000000000000000000000000000000000000009004806316216f391461007657806361bc221a146100995780637cf5dab0146100bc578063a5f3c23b146100e8578063d09de08a1461011d578063dcf537b11461014057610074565b005b610083600480505061016c565b6040518082815260200191505060405180910390f35b6100a6600480505061017f565b6040518082815260200191505060405180910390f35b6100d26004808035906020019091905050610188565b6040518082815260200191505060405180910390f35b61010760048080359060200190919080359060200190919050506101ea565b6040518082815260200191505060405180910390f35b61012a6004805050610201565b6040518082815260200191505060405180910390f35b6101566004808035906020019091905050610217565b6040518082815260200191505060405180910390f35b6000600d9050805080905061017c565b90565b60006000505481565b6000816000600082828250540192505081905550600060005054905080507f3496c3ede4ec3ab3686712aa1c238593ea6a42df83f98a5ec7df9834cfa577c5816040518082815260200191505060405180910390a18090506101e5565b919050565b6000818301905080508090506101fb565b92915050565b600061020d6001610188565b9050610214565b90565b60006007820290508050809050610229565b91905056"
+
+
+CONTRACT_MATH_RUNTIME = "0x60606040523615610074576000357c01000000000000000000000000000000000000000000000000000000009004806316216f391461007657806361bc221a146100995780637cf5dab0146100bc578063a5f3c23b146100e8578063d09de08a1461011d578063dcf537b11461014057610074565b005b610083600480505061016c565b6040518082815260200191505060405180910390f35b6100a6600480505061017f565b6040518082815260200191505060405180910390f35b6100d26004808035906020019091905050610188565b6040518082815260200191505060405180910390f35b61010760048080359060200190919080359060200190919050506101ea565b6040518082815260200191505060405180910390f35b61012a6004805050610201565b6040518082815260200191505060405180910390f35b6101566004808035906020019091905050610217565b6040518082815260200191505060405180910390f35b6000600d9050805080905061017c565b90565b60006000505481565b6000816000600082828250540192505081905550600060005054905080507f3496c3ede4ec3ab3686712aa1c238593ea6a42df83f98a5ec7df9834cfa577c5816040518082815260200191505060405180910390a18090506101e5565b919050565b6000818301905080508090506101fb565b92915050565b600061020d6001610188565b9050610214565b90565b60006007820290508050809050610229565b91905056"
+
+
+CONTRACT_MATH_SOURCE = textwrap.dedent(("""
+    contract Math {
+        uint public counter;
+
+        event Increased(uint value);
+
+        function increment() public returns (uint) {
+            return increment(1);
+        }
+
+        function increment(uint amt) public returns (uint result) {
+            counter += amt;
+            result = counter;
+            Increased(result);
+            return result;
+        }
+
+        function add(int a, int b) public returns (int result) {
+            result = a + b;
+            return result;
+        }
+
+        function multiply7(int a) public returns (int result) {
+            result = a * 7;
+            return result;
+        }
+
+        function return13() public returns (int result) {
+            result = 13;
+            return result;
+        }
+    }
+""")).strip()
+
+CONTRACT_MATH_ABI = json.loads('[{"constant":false,"inputs":[],"name":"return13","outputs":[{"name":"result","type":"int256"}],"type":"function"},{"constant":true,"inputs":[],"name":"counter","outputs":[{"name":"","type":"uint256"}],"type":"function"},{"constant":false,"inputs":[{"name":"amt","type":"uint256"}],"name":"increment","outputs":[{"name":"result","type":"uint256"}],"type":"function"},{"constant":false,"inputs":[{"name":"a","type":"int256"},{"name":"b","type":"int256"}],"name":"add","outputs":[{"name":"result","type":"int256"}],"type":"function"},{"constant":false,"inputs":[],"name":"increment","outputs":[{"name":"","type":"uint256"}],"type":"function"},{"constant":false,"inputs":[{"name":"a","type":"int256"}],"name":"multiply7","outputs":[{"name":"result","type":"int256"}],"type":"function"},{"anonymous":false,"inputs":[{"indexed":false,"name":"value","type":"uint256"}],"name":"Increased","type":"event"}]')  # NOQA
+
+
+@pytest.fixture(scope="session")
+def MATH_CODE():
+    return CONTRACT_MATH_CODE
+
+
+@pytest.fixture(scope="session")
+def MATH_RUNTIME():
+    return CONTRACT_MATH_RUNTIME
+
+
+@pytest.fixture(scope="session")
+def MATH_SOURCE():
+    return CONTRACT_MATH_SOURCE
+
+
+@pytest.fixture(scope="session")
+def MATH_ABI():
+    return CONTRACT_MATH_ABI
+
+
+@pytest.fixture()
+def MATH(MATH_ABI, MATH_CODE, MATH_RUNTIME, MATH_SOURCE):
+    return {
+        'abi': MATH_ABI,
+        'code': MATH_CODE,
+        'code_runtime': MATH_RUNTIME,
+        'source': MATH_SOURCE,
+    }
+
+
+@pytest.fixture()
+def Math(web3, MATH):
+    return web3.eth.contract(**MATH)

--- a/tests/project/conftest.py
+++ b/tests/project/conftest.py
@@ -79,3 +79,42 @@ def MATH(MATH_ABI, MATH_CODE, MATH_RUNTIME, MATH_SOURCE):
 @pytest.fixture()
 def Math(web3, MATH):
     return web3.eth.contract(**MATH)
+
+
+CONTRACT_SIMPLE_CONSTRUCTOR_SOURCE = "contract WithNoArgumentConstructor { uint public data; function WithNoArgumentConstructor() { data = 3; }}"
+CONTRACT_SIMPLE_CONSTRUCTOR_CODE = '0x60606040526003600055602c8060156000396000f3606060405260e060020a600035046373d4a13a8114601a575b005b602260005481565b6060908152602090f3'
+CONTRACT_SIMPLE_CONSTRUCTOR_RUNTIME = '0x606060405260e060020a600035046373d4a13a8114601a575b005b602260005481565b6060908152602090f3'
+CONTRACT_SIMPLE_CONSTRUCTOR_ABI = json.loads('[{"constant":true,"inputs":[],"name":"data","outputs":[{"name":"","type":"uint256"}],"type":"function"},{"inputs":[],"type":"constructor"}]')
+
+
+@pytest.fixture(scope="session")
+def SIMPLE_CONSTRUCTOR_SOURCE():
+    return CONTRACT_SIMPLE_CONSTRUCTOR_SOURCE
+
+
+@pytest.fixture(scope="session")
+def SIMPLE_CONSTRUCTOR_CODE():
+    return CONTRACT_SIMPLE_CONSTRUCTOR_CODE
+
+
+@pytest.fixture(scope="session")
+def SIMPLE_CONSTRUCTOR_RUNTIME():
+    return CONTRACT_SIMPLE_CONSTRUCTOR_RUNTIME
+
+
+@pytest.fixture(scope="session")
+def SIMPLE_CONSTRUCTOR_ABI():
+    return CONTRACT_SIMPLE_CONSTRUCTOR_ABI
+
+
+@pytest.fixture()
+def SIMPLE_CONSTRUCTOR(SIMPLE_CONSTRUCTOR_SOURCE,
+                       SIMPLE_CONSTRUCTOR_CODE,
+                       SIMPLE_CONSTRUCTOR_RUNTIME,
+                       SIMPLE_CONSTRUCTOR_ABI):
+    return {
+        'abi': SIMPLE_CONSTRUCTOR_ABI,
+        'code': SIMPLE_CONSTRUCTOR_CODE,
+        'code_runtime': SIMPLE_CONSTRUCTOR_RUNTIME,
+        'source': SIMPLE_CONSTRUCTOR_SOURCE,
+    }

--- a/tests/project/test_chain_configuration.py
+++ b/tests/project/test_chain_configuration.py
@@ -1,7 +1,0 @@
-from populus.project import Project
-
-
-def test_project_dir_defaults_to_cwd(project_dir):
-    project = Project()
-
-    assert project.project_dir == project_dir

--- a/tests/project/test_chain_configuration.py
+++ b/tests/project/test_chain_configuration.py
@@ -1,0 +1,7 @@
+from populus.project import Project
+
+
+def test_project_dir_defaults_to_cwd(project_dir):
+    project = Project()
+
+    assert project.project_dir == project_dir

--- a/tests/project/test_contract_factories_property.py
+++ b/tests/project/test_contract_factories_property.py
@@ -1,0 +1,13 @@
+import pytest
+
+from populus.project import Project
+
+
+def test_project_contract_factories_property(project_dir, write_project_file,
+                                             MATH):
+    write_project_file('contracts/Math.sol', MATH['source'])
+
+    project = Project(chain='mainnet')
+    assert project.contract_factories.Math.abi == MATH['abi']
+    assert project.contract_factories.Math.code == MATH['code']
+    assert project.contract_factories.Math.code_runtime == MATH['code_runtime']

--- a/tests/project/test_project_compiled_contracts_property.py
+++ b/tests/project/test_project_compiled_contracts_property.py
@@ -1,0 +1,16 @@
+import pytest
+
+from populus.project import Project
+
+
+def test_project_compiled_contracts_with_no_default_env(project_dir,
+                                                        write_project_file,
+                                                        MATH):
+    write_project_file('contracts/Math.sol', MATH['source'])
+
+    project = Project()
+
+    assert 'Math' in project.compiled_contracts
+    assert 'code' in project.compiled_contracts['Math']
+    assert 'code_runtime' in project.compiled_contracts['Math']
+    assert 'abi' in project.compiled_contracts['Math']

--- a/tests/project/test_project_compiled_contracts_property.py
+++ b/tests/project/test_project_compiled_contracts_property.py
@@ -14,3 +14,27 @@ def test_project_compiled_contracts_with_no_default_env(project_dir,
     assert 'code' in project.compiled_contracts['Math']
     assert 'code_runtime' in project.compiled_contracts['Math']
     assert 'abi' in project.compiled_contracts['Math']
+
+    compiled_contracts_object_id = id(project.compiled_contracts)
+
+    assert id(project.compiled_contracts) == compiled_contracts_object_id
+
+
+def test_project_compiled_contracts_auto_update(project_dir,
+                                                write_project_file, MATH,
+                                                SIMPLE_CONSTRUCTOR):
+    write_project_file('contracts/Math.sol', MATH['source'])
+
+    project = Project()
+
+    assert 'Math' in project.compiled_contracts
+    assert 'WithNoArgumentConstructor' not in project.compiled_contracts
+
+    compiled_contracts_object_id = id(project.compiled_contracts)
+
+    write_project_file('contracts/WithNoArgumentConstructor.sol', SIMPLE_CONSTRUCTOR['source'])
+
+    compiled_contracts_object_id != id(project.compiled_contracts)
+
+    assert 'Math' in project.compiled_contracts
+    assert 'WithNoArgumentConstructor' in project.compiled_contracts

--- a/tests/project/test_project_directory_properties.py
+++ b/tests/project/test_project_directory_properties.py
@@ -8,7 +8,7 @@ from populus.utils.filesystem import (
 
 
 def test_project_directory_properties(project_dir):
-    project = Project(project_dir)
+    project = Project()
 
     contracts_dir = get_contracts_dir(project_dir)
     assert project.contracts_dir == contracts_dir

--- a/tests/project/test_project_directory_properties.py
+++ b/tests/project/test_project_directory_properties.py
@@ -1,0 +1,23 @@
+from populus.project import Project
+from populus.utils.filesystem import (
+    get_contracts_dir,
+    get_build_dir,
+    get_compiled_contracts_file_path,
+    get_blockchains_dir,
+)
+
+
+def test_project_directory_properties(project_dir):
+    project = Project(project_dir)
+
+    contracts_dir = get_contracts_dir(project_dir)
+    assert project.contracts_dir == contracts_dir
+
+    build_dir = get_build_dir(project_dir)
+    assert project.build_dir == build_dir
+
+    compiled_contracts_file_path = get_compiled_contracts_file_path(project_dir)
+    assert project.compiled_contracts_file_path == compiled_contracts_file_path
+
+    blockchains_dir = get_blockchains_dir(project_dir)
+    assert project.blockchains_dir == blockchains_dir

--- a/tests/project/test_project_object_defaults_to_cwd.py
+++ b/tests/project/test_project_object_defaults_to_cwd.py
@@ -1,0 +1,7 @@
+from populus.project import Project
+
+
+def test_project_dir_defaults_to_cwd(project_dir):
+    project = Project()
+
+    assert project.project_dir == project_dir

--- a/tests/project/test_web3_configuration.py
+++ b/tests/project/test_web3_configuration.py
@@ -23,14 +23,14 @@ def test_error_if_no_chain_specified_and_no_default_chain(project_dir):
 
 
 def test_uses_default_chain_when_specified(project_dir, write_project_file):
-    ini_contents = textwrap.dedent(("""
-    [populus]
-    project_dir={project_dir}
-    default_chain=custom_chain
-
-    [chain:custom_chain]
-    provider = web3.providers.ipc.IPCProvider
-    """.format(project_dir=project_dir)).strip())
+    ini_contents = '\n'.join((
+        "[populus]",
+        "project_dir={project_dir}",
+        "default_chain=custom_chain",
+        "",
+        "[chain:custom_chain]",
+        "provider = web3.providers.ipc.IPCProvider",
+    )).format(project_dir=project_dir)
     write_project_file('populus.ini', ini_contents)
 
     project = Project()

--- a/tests/project/test_web3_configuration.py
+++ b/tests/project/test_web3_configuration.py
@@ -1,0 +1,62 @@
+import textwrap
+import pytest
+
+from web3 import (
+    IPCProvider,
+    RPCProvider,
+)
+from web3.providers.rpc import (
+    TestRPCProvider,
+)
+
+from populus.utils.chain import (
+    get_default_ipc_path,
+)
+from populus.project import Project
+
+
+def test_error_if_no_chain_specified_and_no_default_chain(project_dir):
+    project = Project()
+
+    with pytest.raises(AttributeError):
+        project.web3
+
+
+def test_uses_default_chain_when_specified(project_dir, write_project_file):
+    ini_contents = textwrap.dedent(("""
+    [populus]
+    project_dir={project_dir}
+    default_chain=custom_chain
+
+    [chain:custom_chain]
+    provider = web3.providers.ipc.IPCProvider
+    """.format(project_dir=project_dir)).strip())
+    write_project_file('populus.ini', ini_contents)
+
+    project = Project()
+
+    web3 = project.web3
+    assert isinstance(web3.currentProvider, IPCProvider)
+
+
+def test_default_configuration_for_test_chain(project_dir):
+    project = Project(chain='test')
+
+    web3 = project.web3
+    assert isinstance(web3.currentProvider, TestRPCProvider)
+
+
+def test_default_configuration_for_morden_chain(project_dir):
+    project = Project(chain='morden')
+
+    web3 = project.web3
+    assert isinstance(web3.currentProvider, IPCProvider)
+    assert web3.currentProvider.ipc_path == get_default_ipc_path(testnet=True)
+
+
+def test_default_configuration_for_testnet_chain(project_dir):
+    project = Project(chain='mainnet')
+
+    web3 = project.web3
+    assert isinstance(web3.currentProvider, IPCProvider)
+    assert web3.currentProvider.ipc_path == get_default_ipc_path(testnet=False)


### PR DESCRIPTION
Implements #122 

- [x] TODO: implement `project.contract_factories` which exposes all of the `web3.eth.contract` objects.

### What was wrong?

* The framework needed a way to persist certain values for project and chain level configuration.
* Users of the framework needed a way to get at some of the internal artifacts that populus uses.

### How was it fixed?

Two things:

- Implement `populus.project.Project` which is an object that exposes many of the artifacts that populus uses internally as properties.
- Implement `$populus config` command which works off of an underlying `populus.ini` file for configuring project and chain level things.

#### Cute Animal Picture

> put a cute animal picture here.

TODO