### PR TITLE
Ability to run "External" chains.

### DIFF
--- a/populus/cli/chain_cmd.py
+++ b/populus/cli/chain_cmd.py
@@ -7,6 +7,7 @@ import click
 from populus.chain import (
     reset_chain,
 )
+from populus.utils.cli import configure_chain
 
 from .main import main
 
@@ -71,3 +72,15 @@ def chain_run(ctx, chain_name, mine, verbosity):
                 gevent.sleep(random.random())
         except KeyboardInterrupt:
             pass
+
+
+@chain_cmd.command('configure')
+@click.argument('chain_name', nargs=1)
+@click.pass_context
+def chain_configure(ctx, chain_name):
+    """
+    Configure a blockchain
+    """
+    project = ctx.obj['PROJECT']
+
+    configure_chain(project, chain_name)

--- a/populus/project.py
+++ b/populus/project.py
@@ -67,6 +67,15 @@ class Project(object):
     def primary_config_file_path(self, value):
         self._primary_config_file_path = value
 
+    def write_config(self, destination_path=None):
+        if destination_path is None:
+            destination_path = self.primary_config_file_path
+
+        with open(destination_path, 'w') as config_file:
+            self.config.write(config_file)
+
+        return destination_path
+
     def load_config(self, config_file_paths=None):
         self._config_file_paths = config_file_paths
 
@@ -79,15 +88,6 @@ class Project(object):
             config_file_paths = [config_file_paths]
 
         self.config = load_config(config_file_paths)
-
-    def write_config(self, destination_path=None):
-        if destination_path is None:
-            destination_path = self.primary_config_file_path
-
-        with open(destination_path, 'w') as config_file:
-            self.config.write(config_file)
-
-        return destination_path
 
     def reload_config(self):
         self.load_config(self._config_file_paths)

--- a/populus/project.py
+++ b/populus/project.py
@@ -42,6 +42,7 @@ from populus.chain import (
     MordenChain,
     MainnetChain,
     LocalGethChain,
+    ExternalChain,
 )
 
 
@@ -203,6 +204,12 @@ class Project(object):
 
         combined_kwargs = dict(**chain_config)
         combined_kwargs.update(chain_kwargs)
+
+        if chain_config.get('is_external'):
+            # TODO: the chain_kwargs is really currently required to contain a
+            # `web3` instance.  This isn't quite congruent with the current
+            # API.
+            return ExternalChain(self, chain_name, *chain_args, **combined_kwargs)
 
         if chain_name == 'morden':
             return MordenChain(self, 'morden', *chain_args, **combined_kwargs)

--- a/populus/utils/transactions.py
+++ b/populus/utils/transactions.py
@@ -41,7 +41,10 @@ def is_account_locked(web3, account):
         return False
 
 
-def wait_for_unlock(web3, account, timeout=0):
+def wait_for_unlock(web3, account=None, timeout=0):
+    if account is None:
+        account = web3.eth.coinbase
+
     with gevent.Timeout(timeout):
         while is_account_locked(web3, account):
             gevent.sleep(random.random())

--- a/tests/chain-management/test_external_chain.py
+++ b/tests/chain-management/test_external_chain.py
@@ -1,0 +1,56 @@
+from populus.project import Project
+from populus.utils.transactions import (
+    wait_for_unlock,
+)
+
+
+def test_external_rpc_chain(project_dir, write_project_file):
+    project = Project()
+
+    with project.get_chain('testrpc') as chain:
+        web3 = chain.web3
+        registrar = chain.registrar
+
+        ini_contents = '\n'.join((
+            "[chain:external]",
+            "is_external=True",
+            "provider=web3.providers.rpc.RPCProvider",
+            "port={port}".format(port=chain.port),
+            "registrar={registrar}".format(registrar=registrar.address),
+        ))
+        write_project_file('populus.ini', ini_contents)
+
+        project.reload_config()
+
+        with project.get_chain('external') as external_chain:
+            ext_web3 = external_chain.web3
+            ext_registrar = external_chain.registrar
+
+            assert ext_web3.eth.coinbase == web3.eth.coinbase
+            assert registrar.address == ext_registrar.address
+
+
+def test_external_ipc_chain(project_dir, write_project_file):
+    project = Project()
+
+    with project.get_chain('temp') as chain:
+        web3 = chain.web3
+        wait_for_unlock(web3, timeout=30)
+        registrar = chain.registrar
+
+        ini_contents = '\n'.join((
+            "[chain:external]",
+            "is_external=True",
+            "ipc_path={ipc_path}".format(ipc_path=chain.geth.ipc_path),
+            "registrar={registrar}".format(registrar=registrar.address),
+        ))
+        write_project_file('populus.ini', ini_contents)
+
+        project.reload_config()
+
+        with project.get_chain('external') as external_chain:
+            ext_web3 = external_chain.web3
+            ext_registrar = external_chain.registrar
+
+            assert ext_web3.eth.coinbase == web3.eth.coinbase
+            assert registrar.address == ext_registrar.address

--- a/tests/chain-management/test_running_development_chain.py
+++ b/tests/chain-management/test_running_development_chain.py
@@ -1,9 +1,0 @@
-from populus.chain import (
-    dev_geth_process,
-)
-
-
-def test_running_development_chain(project_dir):
-    with dev_geth_process(project_dir, 'development') as geth:
-        # TODO: what to assert here?
-        assert geth.is_alive

--- a/tests/chain-management/test_web3_configured_with_default_from_address.py
+++ b/tests/chain-management/test_web3_configured_with_default_from_address.py
@@ -1,0 +1,28 @@
+from geth.accounts import create_new_account
+
+from web3.utils.string import force_text
+
+from populus.project import Project
+
+
+def test_chain_web3_is_preconfigured_with_default_from(project_dir,
+                                                       write_project_file):
+    write_project_file('populus.ini', '[chain:local]')
+
+    project = Project()
+
+    chain = project.get_chain('local')
+
+    default_account = force_text(
+        create_new_account(chain.geth.data_dir, b'a-test-password')
+    )
+
+    project.config.set('chain:local', 'default_account', default_account)
+    project.write_config()
+
+    with chain:
+        web3 = chain.web3
+
+        assert len(web3.eth.accounts) == 2
+        assert web3.eth.defaultAccount == default_account
+        assert web3.eth.coinbase != default_account

--- a/tests/cli/test_configure_chain_helper_fn.py
+++ b/tests/cli/test_configure_chain_helper_fn.py
@@ -1,0 +1,41 @@
+import pytest
+import click
+from click.testing import CliRunner
+
+from geth.accounts import create_new_account
+
+from populus.project import Project
+from populus.utils.cli import (
+    configure_chain,
+)
+
+
+@pytest.mark.parametrize(
+    ('stdin,expected_config'),
+    (
+        ("\nipc\n\n\n", {'provider': 'web3.providers.ipc.IPCProvider'}),
+        ("\nrpc\n\n\n\n", {'provider': 'web3.providers.rpc.RPCProvider'}),
+    )
+)
+def test_select_account_helper_with_indexes(project_dir,
+                                            write_project_file,
+                                            stdin,
+                                            expected_config):
+    write_project_file('populus.ini', '[chain:local]')
+    project = Project()
+
+    @click.command()
+    def wrapper():
+        configure_chain(project, 'local')
+
+    runner = CliRunner()
+    result = runner.invoke(wrapper, [], input=stdin)
+
+    assert result.exit_code == 0
+
+    project.reload_config()
+
+    chain_config = project.config.chains['local']
+    for key, value in expected_config.items():
+        assert key in chain_config
+        assert chain_config[key] == value


### PR DESCRIPTION
### What was wrong?

People won't always want to let populus run the blockchain client for them, or they may use a client like parity or pyethapp.  In these cases, they need a way to have all of the populus chain stuff work even though the chains are external

### How was it fixed?

Added an `ExternalChain` class that handles this case as well as a new command `populus chain configure <chain_name>` that can be used to easily configure chains in an interactive way.

#### Cute Animal Picture

> put a cute animal picture here.

![910cmbp3uzl _sl1500_](https://cloud.githubusercontent.com/assets/824194/17718750/d8374492-63d2-11e6-8428-26da2c778955.jpg)
