### PR TITLE
Fix starting a chain with web3 RPC provider. 

### DIFF
--- a/docs/chain.rst
+++ b/docs/chain.rst
@@ -25,5 +25,86 @@ Each blockchain will have one account generated for it.
 Programmatically launching a new chain
 --------------------------------------
 
-To run a private chain on your local computer see :py:func:`populus.chain.testing_geth_process`.
+Here is an example how to have your own py.test fixture for launching
+a temporary Geth instance with a fresh blockchain.
 
+See
+
+* :py:meth:`populus.project.Project.get_chain`
+
+* :py:class:`populus.project.Project`
+
+* :py:class:`populus.chain.TemporaryGethChain`
+
+* :py:class:`populus.config.Config`
+
+* :py:class:`web3.Web3`
+
+Example:
+
+.. code-block:: python
+
+    import os
+
+    from populus.project import Project
+    from populus.utils.config import Config
+    from web3 import Web3
+    from web3 import RPCProvider
+
+
+    @pytest.yield_fixture(scope="session")
+    def web3() -> Web3:
+        """A py.test fixture to get a Web3 interface to a temporary geth instance.
+
+        This is session scoped fixture.
+        Geth is launched only once during the beginning of the test run.
+
+        Geth will have a huge premined instant balance on its coinbase account.
+        Geth will also mine our transactions on artificially low difficulty level.
+
+        :yield: :py:class:`web3.Web3` instance
+        """
+
+        project = Project()
+
+        # Project is configured using populus.config.Config class
+        # which is a subclass of Python config parser.
+        # Instead of reading .ini file, here we dynamically
+        # construct the configuration.
+        project.config = Config()
+
+        # Settings come for [populus] section of the config.
+        project.config.add_section("populus")
+
+        # Configure where Populus can find our contracts.json
+        build_dir = os.path.join(os.getcwd(), "websauna", "wallet", "ethereum")
+        project.config.set("populus", "build_dir", build_dir)
+
+        chain_kwargs = {
+
+            # Force RPC provider instead of default IPC one
+            "provider": RPCProvider,
+
+            # Adjust geth verbosity for less
+            # output so that test failures are easier to read.
+            "verbosity": "2"
+        }
+
+        # This returns TemporaryGethChain instance as geth_proc
+        with project.get_chain("temp", **chain_kwargs) as geth_proc:
+
+            web3 = geth_proc.web3
+
+            # Allow access to sendTransaction() to use coinbase balance
+            # to deploy contracts. Password is from py-geth
+            # default_blockchain_password file. Assume we don't
+            # run tests for more than 9999 seconds
+            coinbase = web3.eth.coinbase
+            success = web3.personal.unlockAccount(
+                coinbase,
+                passphrase="this-is-not-a-secure-password",
+                duration=9999)
+
+            assert success, "Could not unlock test geth coinbase account"
+
+            yield web3

--- a/populus/chain.py
+++ b/populus/chain.py
@@ -88,10 +88,11 @@ class LocalChainGethProcess(InterceptedStreamsMixin, DevGethProcess):
 
 @contextlib.contextmanager
 def dev_geth_process(project_dir, chain_name):
+
     blockchains_dir = get_blockchains_dir(project_dir)
     local_chain_geth = LocalChainGethProcess(
         chain_name=chain_name,
-        base_dir=blockchains_dir,
+        base_dir=blockchains_dir
     )
     with local_chain_geth as geth:
         yield geth
@@ -145,6 +146,8 @@ class LoggedMainnetGethProcess(LoggingMixin, LiveGethProcess):
 class Chain(object):
     """
     Base class for how populus interacts with the blockchain.
+
+    :param project: Instance of :class:`populus.project.Project`
     """
     project = None
 
@@ -309,7 +312,7 @@ class BaseGethChain(Chain):
         if self._web3 is None:
             if issubclass(self.provider_class, IPCProvider):
                 provider = IPCProvider(self.geth.ipc_path)
-            elif issubclass(self.provider, RPCProvider):
+            elif issubclass(self.provider_class, RPCProvider):
                 provider = RPCProvider(port=self.geth.rpc_port)
             else:
                 raise NotImplementedError(

--- a/populus/project.py
+++ b/populus/project.py
@@ -44,6 +44,8 @@ from populus.chain import (
 
 
 class Project(object):
+
+    #: Instance of :class:`populus.utils.Config`, a subclass of ConfigParser
     config = None
 
     def __init__(self, config_file_paths=None):
@@ -98,7 +100,10 @@ class Project(object):
 
     @property
     def build_dir(self):
-        return get_build_dir(self.project_dir)
+        if self.config.has_option('populus', 'build_dir'):
+            return self.config.get('populus', 'build_dir')
+        else:
+            return get_build_dir(self.project_dir)
 
     @property
     def compiled_contracts_file_path(self):


### PR DESCRIPTION
### What was wrong?

Creating RPC based test chains did not work.

### How was it fixed?

Handle RPCProvider properly. Add flexibility to build dir configuration. Document `project.get_chain()` in narrative documentation.

#### Cute Animal Picture

![mantis](http://i.imgur.com/QKrV9T0.jpg)