### PR TITLE
fix compile watch

### DIFF
--- a/populus/observers.py
+++ b/populus/observers.py
@@ -34,7 +34,6 @@ class ContractSourceChangedEventHandler(FileSystemEventHandler):
     """
     def __init__(self, *args, **kwargs):
         self.project_dir = kwargs.pop('project_dir')
-        self.contract_filters = kwargs.pop('contract_filters')
         self.compiler_kwargs = kwargs.pop('compiler_kwargs')
 
     def on_any_event(self, event):
@@ -43,7 +42,6 @@ class ContractSourceChangedEventHandler(FileSystemEventHandler):
         click.echo("> recompiling...")
         compile_and_write_contracts(
             self.project_dir,
-            *self.contract_filters,
             **self.compiler_kwargs
         )
         click.echo("> watching...")


### PR DESCRIPTION
### What was wrong?

`$ populus compile --watch` is broken as it still expects the `contract_filters` parameter.

### How was it fixed?

Removed the parameter and references to it.

#### Cute Animal Picture

> put a cute animal picture here.

![funny-dog-with-a-bone-5](https://cloud.githubusercontent.com/assets/824194/17829065/c5d02b6e-665e-11e6-8397-cd51347b50de.jpg)
