### PR TITLE
refactor common code from deploy and migrate commands

### DIFF
--- a/populus/chain.py
+++ b/populus/chain.py
@@ -125,6 +125,7 @@ class Chain(object):
     :param project: Instance of :class:`populus.project.Project`
     """
     project = None
+    chain_name = None
 
     def __init__(self, project, chain_name):
         self.project = project

--- a/populus/cli/migrate_cmd.py
+++ b/populus/cli/migrate_cmd.py
@@ -1,20 +1,13 @@
 import click
 
-import gevent
-
 from populus.utils.filesystem import (
     ensure_path_exists,
 )
-from populus.utils.transactions import (
-    is_account_locked,
-    wait_for_unlock,
-)
 from populus.utils.cli import (
     select_chain,
-    select_account,
-    request_account_unlock,
     deploy_contract_and_verify,
     show_chain_sync_progress,
+    get_unlocked_deploy_from_address,
 )
 from populus.migrations.migration import (
     get_migration_classes_for_execution,
@@ -79,20 +72,11 @@ def migrate(ctx, chain_name):
             ))
 
     with project.get_chain(chain_name) as chain:
-        web3 = chain.web3
-
         if chain_name in {'mainnet', 'morden'}:
             show_chain_sync_progress(chain)
 
-        # TODO: pull in the block of code that selects an account
-        account = web3.eth.coinbase
-
-        # Unlock the account if needed.
-        if is_account_locked(web3, account):
-            try:
-                wait_for_unlock(web3, account, 2)
-            except gevent.Timeout:
-                request_account_unlock(chain, account, None)
+        account = get_unlocked_deploy_from_address(chain)
+        chain.web3.eth.defaultAccount = account
 
         # Wait for chain sync if this is a public network.
         if chain_name in {'mainnet', 'morden'}:
@@ -163,8 +147,6 @@ def migrate_init(ctx, chain_name):
 
     chain_section_name = "chain:{0}".format(chain_name)
 
-    chain_config = project.config.chains[chain_name]
-
     if chain_name == 'testrpc':
         ctx.abort("Cannot initialize the {0!r} chain".format(chain_name))
 
@@ -184,41 +166,7 @@ def migrate_init(ctx, chain_name):
             if chain_name in {'mainnet', 'morden'}:
                 show_chain_sync_progress(chain)
 
-            # Choose the address we should deploy from.
-            if 'deploy_from' in chain_config:
-                account = chain_config['deploy_from']
-                if account not in web3.eth.accounts:
-                    raise click.Abort(
-                        "The chain {0!r} is configured to deploy from account {1!r} "
-                        "which was not found in the account list for this chain. "
-                        "Please ensure that this account exists.".format(
-                            chain_name,
-                            account,
-                        )
-                    )
-            else:
-                account = select_account(chain)
-                set_as_deploy_from_msg = (
-                    "Would you like set the address '{0}' as the default"
-                    "`deploy_from` address for the '{1}' chain?".format(
-                        account,
-                        chain_name,
-                    )
-                )
-                if click.confirm(set_as_deploy_from_msg):
-                    project.config.set(chain_section_name, 'deploy_from', account)
-                    click.echo(
-                        "Wrote updated chain configuration to '{0}'".format(
-                            project.write_config()
-                        )
-                    )
-
-            # Unlock the account if needed.
-            if is_account_locked(web3, account):
-                try:
-                    wait_for_unlock(web3, account, 2)
-                except gevent.Timeout:
-                    request_account_unlock(chain, account, None)
+            account = get_unlocked_deploy_from_address(chain)
 
             # Configure web3 to now send from our chosen account by default
             web3.eth.defaultAccount = account

--- a/populus/utils/cli.py
+++ b/populus/utils/cli.py
@@ -1,4 +1,5 @@
 import itertools
+
 import random
 
 import click
@@ -10,6 +11,7 @@ from .transactions import (
     get_contract_address_from_txn,
     wait_for_syncing,
     wait_for_peers,
+    wait_for_unlock,
 )
 
 
@@ -349,3 +351,60 @@ def show_chain_sync_progress(chain):
 
             # break out of the outer loop
             break
+
+
+def get_unlocked_deploy_from_address(chain):
+    """
+    Combination of other utils to get the address deployments should come from.
+
+    Defaults to the one set in the config.
+    If not set, asks for one.
+    If not in config, asks if it should be set as default.
+    If not unlocked, askes for password to unlock.
+    """
+    web3 = chain.web3
+    chain_config = chain.chain_config
+    chain_name = chain.chain_name
+    chain_section_name = "chain:{name}".format(name=chain_name)
+    project = chain.project
+    config = project.config
+
+    # Choose the address we should deploy from.
+    if 'deploy_from' in chain_config:
+        account = chain_config['deploy_from']
+        if account not in web3.eth.accounts:
+            raise click.Abort(
+                "The chain {0!r} is configured to deploy from account {1!r} "
+                "which was not found in the account list for this chain. "
+                "Please ensure that this account exists.".format(
+                    chain_name,
+                    account,
+                )
+            )
+    else:
+        account = select_account(chain)
+        set_as_deploy_from_msg = (
+            "Would you like set the address '{0}' as the default"
+            "`deploy_from` address for the '{1}' chain?".format(
+                account,
+                chain_name,
+            )
+        )
+        if click.confirm(set_as_deploy_from_msg):
+            if not config.has_section(chain_section_name):
+                config.add_section(chain_section_name)
+            config.set(chain_section_name, 'deploy_from', account)
+            click.echo(
+                "Wrote updated chain configuration to '{0}'".format(project.write_config())
+            )
+
+    # Unlock the account if needed.
+    if is_account_locked(web3, account):
+        try:
+            # in case the chain is still spinning up, give it a moment to
+            # unlock itself.
+            wait_for_unlock(web3, account, 2)
+        except gevent.Timeout:
+            request_account_unlock(chain, account, None)
+
+    return account

--- a/populus/utils/cli.py
+++ b/populus/utils/cli.py
@@ -16,6 +16,10 @@ from .transactions import (
 
 
 def select_chain(project):
+    """
+    Present the user with a prompt to select which of the project chains they
+    want to use.
+    """
     chain_options = set(project.config.chains.keys())
 
     choose_chain_msg = "\n".join(itertools.chain((
@@ -41,6 +45,10 @@ def select_chain(project):
 
 
 def select_account(chain):
+    """
+    Present the user with a prompt to select which of the chain accounts they
+    would like to use.
+    """
     all_accounts = chain.web3.eth.accounts
     if not all_accounts:
         raise click.Abort("No accounts found on chain.")
@@ -80,6 +88,14 @@ def select_account(chain):
 
 
 def configure_chain(project, chain_name):
+    """
+    Interactive configuration of an existing or new chain.
+
+    - is it external?
+    - rpc or ipc?
+    - rpc/ipc configuration
+    - select default account (web3.eth.defaultAccount)
+    """
     is_existing_chain = chain_name in project.config.chains
 
     chain_section_header = "chain:{chain_name}".format(chain_name=chain_name)
@@ -195,6 +211,9 @@ def configure_chain(project, chain_name):
 
 
 def request_account_unlock(chain, account, timeout):
+    """
+    Present a password prompt to unlock the given account.
+    """
     if not is_account_locked(chain.web3, account):
         raise click.Abort(
             "The account `{0}` is already unlocked".format(account)
@@ -216,6 +235,11 @@ def deploy_contract_and_verify(ContractFactory,
                                contract_name,
                                deploy_transaction=None,
                                deploy_arguments=None):
+    """
+    Deploy a contract, displaying information about the deploy process as it
+    happens.  This also verifies that the deployed contract's bytecode matches
+    the expected value.
+    """
     if deploy_transaction is None:
         deploy_transaction = {}
     if deploy_arguments is None:
@@ -298,6 +322,9 @@ def deploy_contract_and_verify(ContractFactory,
 
 
 def show_chain_sync_progress(chain):
+    """
+    Display the syncing status of a chain as a progress bar
+    """
     web3 = chain.web3
 
     if not web3.net.peerCount:

--- a/tests/cli/test_get_unlocked_deploy_from_address_helper_fn.py
+++ b/tests/cli/test_get_unlocked_deploy_from_address_helper_fn.py
@@ -1,0 +1,100 @@
+import pytest
+from flaky import flaky
+import click
+from click.testing import CliRunner
+
+from geth.accounts import create_new_account
+
+from populus.project import Project
+from populus.utils.cli import (
+    get_unlocked_deploy_from_address,
+)
+
+
+@pytest.fixture()
+def local_chain(project_dir, write_project_file):
+    write_project_file('populus.ini', '[chain:local]')
+
+    project = Project()
+    chain = project.get_chain('local')
+
+    # create a new account
+    create_new_account(chain.geth.data_dir, b'a-test-password')
+
+    return chain
+
+
+@flaky
+def test_get_unlocked_deploy_from_address_with_no_config(local_chain):
+    project = Project()
+    chain = local_chain
+
+    with chain:
+        @click.command()
+        def wrapper():
+            account = get_unlocked_deploy_from_address(chain)
+            print("~~{0}~~".format(account))
+
+        runner = CliRunner()
+        result = runner.invoke(wrapper, [], input="1\ny\na-test-password\n")
+
+        deploy_from = chain.web3.eth.accounts[1]
+        assert result.exit_code == 0
+        expected = "~~{0}~~".format(deploy_from)
+        assert expected in result.output
+
+        project.reload_config()
+        assert project.config.chains['local']['deploy_from'] == deploy_from
+
+
+@flaky
+def test_helper_fn_with_unlocked_pre_configured_account(local_chain):
+    chain = local_chain
+    project = chain.project
+
+    with chain:
+        web3 = chain.web3
+        project.config.set('chain:local', 'deploy_from', web3.eth.coinbase)
+        project.write_config()
+        project.reload_config()
+
+        @click.command()
+        def wrapper():
+            account = get_unlocked_deploy_from_address(chain)
+            print("~~{0}~~".format(account))
+
+        runner = CliRunner()
+        result = runner.invoke(wrapper, [])
+
+        assert result.exit_code == 0
+        expected = "~~{0}~~".format(web3.eth.coinbase)
+        assert expected in result.output
+
+        project.reload_config()
+        assert project.config.chains['local']['deploy_from'] == web3.eth.coinbase
+
+
+@flaky
+def test_helper_fn_with_locked_pre_configured_account(local_chain):
+    chain = local_chain
+    project = chain.project
+
+    with chain:
+        web3 = chain.web3
+        project.config.set('chain:local', 'deploy_from', web3.eth.accounts[1])
+        project.write_config()
+
+        @click.command()
+        def wrapper():
+            account = get_unlocked_deploy_from_address(chain)
+            print("~~{0}~~".format(account))
+
+        runner = CliRunner()
+        result = runner.invoke(wrapper, [], input="a-test-password\n")
+
+        assert result.exit_code == 0
+        expected = "~~{0}~~".format(web3.eth.accounts[1])
+        assert expected in result.output
+
+        project.reload_config()
+        assert project.config.chains['local']['deploy_from'] == web3.eth.accounts[1]


### PR DESCRIPTION
### What was wrong?

There was code duplication in the `deploy`, `migrate` and `migrate init` commands for selecting the account you wanted to deploy from.

### How was it fixed?

Extracted the common functionality into a helper fn that is tested.

#### Cute Animal Picture

> put a cute animal picture here.

![types-dog-toys](https://cloud.githubusercontent.com/assets/824194/17912003/20c540da-694e-11e6-8888-c74bdadf3904.jpg)
