### PR TITLE
remove gevent monkeypatching

### DIFF
--- a/populus/chain.py
+++ b/populus/chain.py
@@ -27,7 +27,7 @@ from populus.utils.functional import (
 )
 from populus.utils.networking import (
     get_open_port,
-    wait_for_http_connection,
+    wait_for_connection,
 )
 from populus.utils.module_loading import (
     import_string,
@@ -506,7 +506,7 @@ class TestRPCChain(Chain):
         testrpc.rpc_configure('net_version', 1)
         testrpc.evm_mine()
 
-        wait_for_http_connection('127.0.0.1', self.port)
+        wait_for_connection('127.0.0.1', self.port)
         self._running = True
         return self
 

--- a/populus/utils/networking.py
+++ b/populus/utils/networking.py
@@ -1,7 +1,12 @@
+import sys
 import random
 
 import gevent
 from gevent import socket
+
+
+if sys.version_info.major == 2:
+    ConnectionRefusedError = socket.error
 
 
 def get_open_port():
@@ -20,7 +25,7 @@ def wait_for_connection(host, port, timeout=30):
             s.timeout = 1
             try:
                 s.connect((host, port))
-            except socket.timoeout:
+            except (socket.timeout, ConnectionRefusedError):
                 gevent.sleep(random.random())
                 continue
             else:

--- a/populus/utils/networking.py
+++ b/populus/utils/networking.py
@@ -1,17 +1,11 @@
 import random
 
 import gevent
-from gevent import monkey
-
-
-monkey.patch_socket()
-
-
-import requests  # noqa
+from gevent import socket
 
 
 def get_open_port():
-    s = gevent.socket.socket(gevent.socket.AF_INET, gevent.socket.SOCK_STREAM)
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.bind(("", 0))
     s.listen(1)
     port = s.getsockname()[1]
@@ -19,12 +13,14 @@ def get_open_port():
     return port
 
 
-def wait_for_http_connection(host, port, timeout=30):
+def wait_for_connection(host, port, timeout=30):
     with gevent.Timeout(timeout):
         while True:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.timeout = 1
             try:
-                requests.post("http://{0}:{1}".format(host, port))
-            except requests.ConnectionError:
+                s.connect((host, port))
+            except socket.timoeout:
                 gevent.sleep(random.random())
                 continue
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ py-geth>=1.1.0
 py-solc>=0.4.0
 pysha3>=0.3
 pytest>=2.7.2
-requests>=2.7.0
 toposort>=1.4
 watchdog>=0.8.3
 web3>=2.0.0

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
         "py-solc>=0.4.0",
         "pysha3>=0.3",
         "pytest>=2.7.2",
-        "requests>=2.7.0",
         "toposort>=1.4",
         "watchdog>=0.8.3",
         "web3>=2.0.0",

--- a/tests/utility/test_wait_for_http_connection.py
+++ b/tests/utility/test_wait_for_http_connection.py
@@ -1,0 +1,65 @@
+import random
+import gevent
+import contextlib
+
+try:
+    from http.server import (
+        HTTPServer,
+        BaseHTTPRequestHandler,
+    )
+except ImportError:
+    from BaseHTTPServer import (
+        HTTPServer,
+        BaseHTTPRequestHandler,
+    )
+
+from populus.utils.networking import (
+    get_open_port,
+    wait_for_connection,
+)
+
+
+def test_wait_for_connection():
+    success_tracker = {}
+    port = get_open_port()
+
+    def _do_client():
+        try:
+            wait_for_connection('localhost', port)
+        except gevent.Timeout:
+            success_tracker['client_success'] = False
+        else:
+            success_tracker['client_success'] = True
+
+
+    class TestHTTPServer(HTTPServer):
+        timeout = 30
+
+        def handle_timeout():
+            success_tracker['server_success'] = False
+
+        def handle_error():
+            success_tracker['server_success'] = True
+
+    def _do_server():
+        server = TestHTTPServer(('localhost', port), BaseHTTPRequestHandler)
+        server.timeout = 30
+
+        server.handle_request()
+        success_tracker.setdefault('server_success', True)
+
+    client_thread = gevent.spawn(_do_client)
+    server_thread = gevent.spawn(_do_server)
+
+    try:
+        with gevent.Timeout(5):
+            while 'client_success' not in success_tracker and 'server_success' not in success_tracker:
+                gevent.sleep(random.random())
+    except gevent.Timeout:
+        pass
+
+    assert 'client_success' in success_tracker
+    assert success_tracker['client_success'] is True
+
+    assert 'server_success' in success_tracker
+    assert success_tracker['server_success'] is True

--- a/tests/utility/test_wait_for_http_connection.py
+++ b/tests/utility/test_wait_for_http_connection.py
@@ -19,7 +19,7 @@ from populus.utils.networking import (
 )
 
 
-def test_wait_for_connection():
+def test_wait_for_connection_success():
     success_tracker = {}
     port = get_open_port()
 
@@ -63,3 +63,28 @@ def test_wait_for_connection():
 
     assert 'server_success' in success_tracker
     assert success_tracker['server_success'] is True
+
+
+def test_wait_for_connection_success():
+    success_tracker = {}
+    port = get_open_port()
+
+    def _do_client():
+        try:
+            wait_for_connection('localhost', port, 2)
+        except gevent.Timeout:
+            success_tracker['client_success'] = False
+        else:
+            success_tracker['client_success'] = True
+
+    client_thread = gevent.spawn(_do_client)
+
+    try:
+        with gevent.Timeout(5):
+            while 'client_success' not in success_tracker:
+                gevent.sleep(random.random())
+    except gevent.Timeout:
+        pass
+
+    assert 'client_success' in success_tracker
+    assert success_tracker['client_success'] is False


### PR DESCRIPTION
### What was wrong?

The `populus.utils.networking` module implemented a gevent monkeypatch because of the underlying use of the `requests` library.  This wasn't ideal since monkeypatching doesn't always interact nicely with other things.

### How was it fixed?

Used the `gevent.socket` to make the connection instead.

#### Cute Animal Picture

> put a cute animal picture here.

![dog_17_kh0034_01_p](https://cloud.githubusercontent.com/assets/824194/18098205/73695240-6e9e-11e6-89f5-51634437686f.JPG)
