### PR TITLE
fix module loading for migrations within test runs.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,12 +3,6 @@ import os
 import pytest
 
 
-from gevent import monkey
-
-
-monkey.patch_all()
-
-
 @pytest.fixture()
 def project_dir(tmpdir, monkeypatch):
     from populus.utils.filesystem import (

--- a/populus/chain.py
+++ b/populus/chain.py
@@ -394,6 +394,8 @@ class ExternalChain(Chain):
 
         if provider_class == RPCProvider:
             host = kwargs.pop('host', '127.0.0.1')
+            # TODO: this integer casting needs to be done downstream in
+            # web3.py.
             port = int(kwargs.pop('port', 8545))
             provider = provider_class(host=host, port=port)
         elif provider_class == IPCProvider:

--- a/populus/migrations/loading.py
+++ b/populus/migrations/loading.py
@@ -64,6 +64,10 @@ def load_project_migrations(project_dir):
         import_module(module_path)
         for module_path in migration_module_paths
     ]
+
+    for migration_module in migration_modules:
+        reload(migration_module)
+
     migration_classes = [
         getattr(migration_module, 'Migration')
         for migration_module in migration_modules

--- a/populus/migrations/loading.py
+++ b/populus/migrations/loading.py
@@ -61,12 +61,9 @@ def load_project_migrations(project_dir):
         reload(import_module(migration_base_path))
 
     migration_modules = [
-        import_module(module_path)
+        reload(import_module(module_path))
         for module_path in migration_module_paths
     ]
-
-    for migration_module in migration_modules:
-        reload(migration_module)
 
     migration_classes = [
         getattr(migration_module, 'Migration')

--- a/tests/cli/test_makemigration.py
+++ b/tests/cli/test_makemigration.py
@@ -1,3 +1,4 @@
+import sys
 import os
 from click.testing import CliRunner
 
@@ -10,7 +11,6 @@ from populus.cli import main
 
 
 def test_makemigration(project_dir, write_project_file):
-    print('Project Dir:', project_dir)
     runner = CliRunner()
 
     write_project_file(
@@ -58,15 +58,14 @@ def test_makemigration(project_dir, write_project_file):
 
 
 def test_makemigration_works_with_no_contracts(project_dir):
-    print('Project Dir:', project_dir)
     runner = CliRunner()
 
-    result = runner.invoke(main, ['makemigration', 'initial'])
+    result = runner.invoke(main, ['makemigration', 'my_first_migration'])
     assert result.exit_code == 0, result.output + str(result.exception)
 
     migrations_dir = get_migrations_dir(project_dir, lazy_create=False)
     assert os.path.exists(migrations_dir)
-    assert os.path.exists(os.path.join(migrations_dir, '0001_initial.py'))
+    assert os.path.exists(os.path.join(migrations_dir, '0001_my_first_migration.py'))
 
     project = Project()
 

--- a/tests/cli/test_makemigration.py
+++ b/tests/cli/test_makemigration.py
@@ -73,6 +73,6 @@ def test_makemigration_works_with_no_contracts(project_dir):
 
     m1 = project.migrations[0]
 
-    assert m1.migration_id == '0001_initial'
+    assert m1.migration_id == '0001_my_first_migration'
     assert m1.dependencies == []
     assert m1.compiled_contracts == {}

--- a/tests/cli/test_makemigration.py
+++ b/tests/cli/test_makemigration.py
@@ -10,6 +10,7 @@ from populus.cli import main
 
 
 def test_makemigration(project_dir, write_project_file):
+    print('Project Dir:', project_dir)
     runner = CliRunner()
 
     write_project_file(
@@ -54,3 +55,25 @@ def test_makemigration(project_dir, write_project_file):
 
     assert m3.migration_id == '0003_custom_name'
     assert m3.dependencies == ['0002_auto']
+
+
+def test_makemigration_works_with_no_contracts(project_dir):
+    print('Project Dir:', project_dir)
+    runner = CliRunner()
+
+    result = runner.invoke(main, ['makemigration', 'initial'])
+    assert result.exit_code == 0, result.output + str(result.exception)
+
+    migrations_dir = get_migrations_dir(project_dir, lazy_create=False)
+    assert os.path.exists(migrations_dir)
+    assert os.path.exists(os.path.join(migrations_dir, '0001_initial.py'))
+
+    project = Project()
+
+    assert len(project.migrations) == 1
+
+    m1 = project.migrations[0]
+
+    assert m1.migration_id == '0001_initial'
+    assert m1.dependencies == []
+    assert m1.compiled_contracts == {}

--- a/tests/migrations/test_serialization_of_deferred_values.py
+++ b/tests/migrations/test_serialization_of_deferred_values.py
@@ -10,7 +10,7 @@ from populus.migrations.writer import (
 )
 
 
-class TestDeferred(DeferredValue):
+class Deferred(DeferredValue):
     a = None
     b = None
     c = None
@@ -27,9 +27,9 @@ class TestDeferred(DeferredValue):
 )\n""",
         ),
         (
-            TestDeferred.defer(c=4),
+            Deferred.defer(c=4),
             {__name__},
-            """{module_part}.TestDeferred.defer(
+            """{module_part}.Deferred.defer(
     c=4,
 )\n""".format(module_part=__name__),
         ),


### PR DESCRIPTION
### What was wrong?

The migration module loading was not reloading individual migration modules so cached versions were being returned.

### How was it fixed?

Added a call to `reload` for each module.

#### Cute Animal Picture

> put a cute animal picture here.

![b0091mhmae_002 _sl210_](https://cloud.githubusercontent.com/assets/824194/18100013/68e07b02-6ea6-11e6-8ec5-9fe6f754ff51.jpg)
