### PR TITLE
Fix is_same_path util for python2

### DIFF
--- a/populus/utils/filesystem.py
+++ b/populus/utils/filesystem.py
@@ -1,8 +1,13 @@
 import os
+import sys
 import shutil
 import fnmatch
 import tempfile
 import contextlib
+
+
+if sys.version_info.major == 2:
+    FileNotFoundError = OSError
 
 
 def ensure_path_exists(dir_path):

--- a/tests/utility/test_is_same_path_util.py
+++ b/tests/utility/test_is_same_path_util.py
@@ -1,0 +1,25 @@
+import os
+
+from populus.utils.filesystem import is_same_path
+
+
+def test_paths_that_dont_exist(project_dir):
+    assert not os.path.exists('not-a-real-path')
+    assert not os.path.exists('also-not-a-real-path')
+
+    assert not is_same_path('not-a-real-path', 'also-not-a-real-path')
+
+
+def test_paths_that_exist(project_dir, write_project_file):
+    write_project_file('not-a-real-path')
+    write_project_file('also-not-a-real-path')
+
+    assert not is_same_path('not-a-real-path', 'also-not-a-real-path')
+
+
+def test_relpath_and_abspath(project_dir):
+    abs_path = os.path.abspath('this-is-a-path')
+    rel_path = os.path.relpath('this-is-a-path')
+
+    assert abs_path != rel_path
+    assert is_same_path(abs_path, rel_path)


### PR DESCRIPTION
### What was wrong?

`FileNotFound` error is python3 only

### How was it fixed?

Added an alias to `OSError` when running in python2 (and tests)

#### Cute Animal Picture

> put a cute animal picture here.

![130708_cat_bird_l](https://cloud.githubusercontent.com/assets/824194/18100280/7d1dde7e-6ea7-11e6-9db5-074bdb64c89f.jpg)
