### PR TITLE
allow testrpc chain to be run with chain command

### DIFF
--- a/populus/cli/chain_cmd.py
+++ b/populus/cli/chain_cmd.py
@@ -15,6 +15,7 @@ from populus.utils.cli import (
     get_unlocked_deploy_from_address,
 )
 from populus.chain import (
+    BaseGethChain,
     reset_chain,
 )
 
@@ -70,10 +71,9 @@ def chain_run(ctx, chain_name, mine, verbosity):
 
     chain = project.get_chain(chain_name)
 
-    # TODO: the chain should implement this method so that it's accessible
-    # on non-geth based backents.
-    chain.geth.register_stdout_callback(click.echo)
-    chain.geth.register_stderr_callback(functools.partial(click.echo, err=True))
+    if isinstance(chain, BaseGethChain):
+        chain.geth.register_stdout_callback(click.echo)
+        chain.geth.register_stderr_callback(functools.partial(click.echo, err=True))
 
     with chain:
         try:


### PR DESCRIPTION
### What was wrong?

The `$ populus chain run` command didn't work with the `testrpc` chain since it had code specific to the `geth` based chains

### How was it fixed?

Added a conditional so that this code only runs when a `geth` based chain is in use.

#### Cute Animal Picture

> put a cute animal picture here.

![cat-birdin-mouth-1-amd-1024x682](https://cloud.githubusercontent.com/assets/824194/18100405/170b3da6-6ea8-11e6-8c08-713d082e1296.jpg)
