### PR TITLE
fix testrpc wait for block

### DIFF
--- a/populus/utils/wait.py
+++ b/populus/utils/wait.py
@@ -22,7 +22,9 @@ def wait_for_block_number(web3, block_number=1, timeout=120):
         while web3.eth.blockNumber < block_number:
             if isinstance(web3.currentProvider, TestRPCProvider):
                 web3._requestManager.request_blocking("evm_mine", [])
-            gevent.sleep(random.random())
+                gevent.sleep(0)
+            else:
+                gevent.sleep(random.random())
     return web3.eth.getBlock(block_number)
 
 


### PR DESCRIPTION
### What was wrong?

The `wait.for_block` when using testrpc should not sleep for any significant duration since mining is immediate.  Otherwise block times will be around `0.5` seconds which is *longggg* for testing.

### How was it fixed?

Changed the conditional so that it does a `gevent.sleep(0)` instead.

#### Cute Animal Picture

> put a cute animal picture here.

![inflatable-wizard-hat-for-cats-7664](https://cloud.githubusercontent.com/assets/824194/18292296/b38cec00-7449-11e6-9b0b-c256d1cfbfb7.jpg)
