### PR TITLE
Implement pulling contract factories from migrations

### DIFF
--- a/docs/chain.rst
+++ b/docs/chain.rst
@@ -288,6 +288,18 @@ contracts.
     bytecode for any library dependencies for the given contract should be
     validated to match the on chain bytecode.
 
+    If your project has no project migrations then the data used for these
+    contract factories will come directly from the compiled project contracts.
+
+    If your project has migrations then the data used to build your contract
+    factories will be populutated as follows.:
+
+        #. The newest migration that has been run which deploys the requested
+           contract.
+        #. The newest migration which contains this contract in it's
+           ``compiled_contracts`` property
+        #. The compiled project contracts.
+
 
 .. py:method:: Chain.get_contract(contract_name, link_dependencies=None, validate_bytecode=True)
 

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -241,7 +241,7 @@ provides the following operation classes.
   without waiting.
 
 
-.. py:class:: DeployContract(contract_name, transaction=None, arguments=None, verify=True, libraries=None, timeout=180)
+.. py:class:: DeployContract(contract_name, transaction=None, arguments=None, verify=True, libraries=None, timeout=180, contract_registrar_name=None)
 
   Deployes the contract designated by ``contract_name`` from the migration's
   ``compiled_contracts`` property.
@@ -269,6 +269,11 @@ provides the following operation classes.
   The operation will wait up to the ``timeout`` value for the deployment
   transaction to be mined unless set to ``None`` in which case the
   operation will continue on without waiting.
+
+  Upon successful deployment a record will be written to the chain registrar
+  contract under the string ``contract/{contract_name}``.  If
+  ``contract_registrar_name`` is provided, then this name will be used in place
+  of the ``contract_name``.
 
 
 .. py:class:: TransactContract(contract_address, contract_name, method_name, arguments=None, transaction=None, timeout=180)

--- a/populus/chain.py
+++ b/populus/chain.py
@@ -55,6 +55,9 @@ from populus.utils.chains import (
     get_geth_logfile_path,
 )
 
+from populus.migrations.migration import (
+    get_compiled_contracts_from_migrations,
+)
 from populus.migrations.registrar import (
     get_compiled_registrar_contract,
 )
@@ -182,9 +185,17 @@ class Chain(object):
 
     @cached_property
     def contract_factories(self):
+        if self.project.migrations:
+            compiled_contracts = get_compiled_contracts_from_migrations(
+                self.project.migrations,
+                self,
+            )
+        else:
+            compiled_contracts = self.project.compiled_contracts
+
         return construct_contract_factories(
             self.web3,
-            self.project.compiled_contracts,
+            compiled_contracts,
         )
 
     @property

--- a/populus/migrations/operations.py
+++ b/populus/migrations/operations.py
@@ -99,6 +99,7 @@ class SendTransaction(Operation):
 
 class DeployContract(Operation):
     contract_name = None
+    contract_registrar_name = None
     transaction = None
     timeout = 180
     libraries = None
@@ -110,11 +111,13 @@ class DeployContract(Operation):
                  arguments=None,
                  verify=True,
                  libraries=None,
-                 timeout=180):
+                 timeout=180,
+                 contract_registrar_name=None):
         if libraries is None:
             libraries = {}
 
         self.contract_name = contract_name
+        self.contract_registrar_name = contract_registrar_name
         self.libraries = libraries
 
         if timeout is None and verify:
@@ -146,6 +149,7 @@ class DeployContract(Operation):
         resolver = Resolver(chain)
 
         contract_name = resolver(self.contract_name)
+        contract_registrar_name = resolver(self.contract_registrar_name)
         libraries = {
             resolver(key): resolver(value)
             for key, value in resolver(self.libraries).items()
@@ -228,10 +232,11 @@ class DeployContract(Operation):
                         ),
                     )
             return {
-                'contract-address': contract_address,
                 'deploy-transaction-hash': deploy_transaction_hash,
                 'canonical-contract-address': Address.defer(
-                    key='/'.join(('contract', contract_name)),
+                    key='contract/{name}'.format(
+                        name=contract_registrar_name or contract_name,
+                    ),
                     value=contract_address,
                 ),
             }

--- a/tests/chain-management/conftest.py
+++ b/tests/chain-management/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 import json
-import textwrap
 
 
 CONTRACT_MATH_CODE = "0x606060405261022e806100126000396000f360606040523615610074576000357c01000000000000000000000000000000000000000000000000000000009004806316216f391461007657806361bc221a146100995780637cf5dab0146100bc578063a5f3c23b146100e8578063d09de08a1461011d578063dcf537b11461014057610074565b005b610083600480505061016c565b6040518082815260200191505060405180910390f35b6100a6600480505061017f565b6040518082815260200191505060405180910390f35b6100d26004808035906020019091905050610188565b6040518082815260200191505060405180910390f35b61010760048080359060200190919080359060200190919050506101ea565b6040518082815260200191505060405180910390f35b61012a6004805050610201565b6040518082815260200191505060405180910390f35b6101566004808035906020019091905050610217565b6040518082815260200191505060405180910390f35b6000600d9050805080905061017c565b90565b60006000505481565b6000816000600082828250540192505081905550600060005054905080507f3496c3ede4ec3ab3686712aa1c238593ea6a42df83f98a5ec7df9834cfa577c5816040518082815260200191505060405180910390a18090506101e5565b919050565b6000818301905080508090506101fb565b92915050565b600061020d6001610188565b9050610214565b90565b60006007820290508050809050610229565b91905056"
@@ -9,39 +8,39 @@ CONTRACT_MATH_CODE = "0x606060405261022e806100126000396000f360606040523615610074
 CONTRACT_MATH_RUNTIME = "0x60606040523615610074576000357c01000000000000000000000000000000000000000000000000000000009004806316216f391461007657806361bc221a146100995780637cf5dab0146100bc578063a5f3c23b146100e8578063d09de08a1461011d578063dcf537b11461014057610074565b005b610083600480505061016c565b6040518082815260200191505060405180910390f35b6100a6600480505061017f565b6040518082815260200191505060405180910390f35b6100d26004808035906020019091905050610188565b6040518082815260200191505060405180910390f35b61010760048080359060200190919080359060200190919050506101ea565b6040518082815260200191505060405180910390f35b61012a6004805050610201565b6040518082815260200191505060405180910390f35b6101566004808035906020019091905050610217565b6040518082815260200191505060405180910390f35b6000600d9050805080905061017c565b90565b60006000505481565b6000816000600082828250540192505081905550600060005054905080507f3496c3ede4ec3ab3686712aa1c238593ea6a42df83f98a5ec7df9834cfa577c5816040518082815260200191505060405180910390a18090506101e5565b919050565b6000818301905080508090506101fb565b92915050565b600061020d6001610188565b9050610214565b90565b60006007820290508050809050610229565b91905056"
 
 
-CONTRACT_MATH_SOURCE = textwrap.dedent(("""
-    contract Math {
-        uint public counter;
+CONTRACT_MATH_SOURCE = ("""
+contract Math {
+    uint public counter;
 
-        event Increased(uint value);
+    event Increased(uint value);
 
-        function increment() public returns (uint) {
-            return increment(1);
-        }
-
-        function increment(uint amt) public returns (uint result) {
-            counter += amt;
-            result = counter;
-            Increased(result);
-            return result;
-        }
-
-        function add(int a, int b) public returns (int result) {
-            result = a + b;
-            return result;
-        }
-
-        function multiply7(int a) public returns (int result) {
-            result = a * 7;
-            return result;
-        }
-
-        function return13() public returns (int result) {
-            result = 13;
-            return result;
-        }
+    function increment() public returns (uint) {
+        return increment(1);
     }
-""")).strip()
+
+    function increment(uint amt) public returns (uint result) {
+        counter += amt;
+        result = counter;
+        Increased(result);
+        return result;
+    }
+
+    function add(int a, int b) public returns (int result) {
+        result = a + b;
+        return result;
+    }
+
+    function multiply7(int a) public returns (int result) {
+        result = a * 7;
+        return result;
+    }
+
+    function return13() public returns (int result) {
+        result = 13;
+        return result;
+    }
+}
+""").strip()
 
 CONTRACT_MATH_ABI = json.loads('[{"constant":false,"inputs":[],"name":"return13","outputs":[{"name":"result","type":"int256"}],"type":"function"},{"constant":true,"inputs":[],"name":"counter","outputs":[{"name":"","type":"uint256"}],"type":"function"},{"constant":false,"inputs":[{"name":"amt","type":"uint256"}],"name":"increment","outputs":[{"name":"result","type":"uint256"}],"type":"function"},{"constant":false,"inputs":[{"name":"a","type":"int256"},{"name":"b","type":"int256"}],"name":"add","outputs":[{"name":"result","type":"int256"}],"type":"function"},{"constant":false,"inputs":[],"name":"increment","outputs":[{"name":"","type":"uint256"}],"type":"function"},{"constant":false,"inputs":[{"name":"a","type":"int256"}],"name":"multiply7","outputs":[{"name":"result","type":"int256"}],"type":"function"},{"anonymous":false,"inputs":[{"indexed":false,"name":"value","type":"uint256"}],"name":"Increased","type":"event"}]')  # NOQA
 
@@ -76,13 +75,95 @@ def MATH(MATH_ABI, MATH_CODE, MATH_RUNTIME, MATH_SOURCE):
     }
 
 
-MULTIPLY13_LIBRARY_SOURCE = textwrap.dedent(("""
+CONTRACT_MATH_V2_CODE = "0x606060405261017e806100126000396000f36060604052361561006c5760e060020a600035046316216f39811461006e5780632baeceb7146100775780633a9ebefd1461008657806361bc221a1461009d5780637cf5dab0146100a6578063a5f3c23b146100f6578063d09de08a14610110578063dcf537b11461011f575b005b6100fe600d5b90565b6100fe600061012e600161008d565b6100fe6004355b6000805482111561013557610002565b6100fe60005481565b6100fe6004355b60008054820181556040805183815290517f3496c3ede4ec3ab3686712aa1c238593ea6a42df83f98a5ec7df9834cfa577c59181900360200190a160006000505490505b919050565b602435600435015b60408051918252519081900360200190f35b6100fe600061012e60016100ad565b6100fe600435600781026100f1565b9050610074565b6000805483900390556040805183815290517f4fa5877b6c8d448ebaefa4048625aee504905823a70902d5f9a10a0b6ef0e1279181900360200190a160006000505490506100f156"
+
+CONTRACT_MATH_V2_RUNTIME = "0x6060604052361561006c5760e060020a600035046316216f39811461006e5780632baeceb7146100775780633a9ebefd1461008657806361bc221a1461009d5780637cf5dab0146100a6578063a5f3c23b146100f6578063d09de08a14610110578063dcf537b11461011f575b005b6100fe600d5b90565b6100fe600061012e600161008d565b6100fe6004355b6000805482111561013557610002565b6100fe60005481565b6100fe6004355b60008054820181556040805183815290517f3496c3ede4ec3ab3686712aa1c238593ea6a42df83f98a5ec7df9834cfa577c59181900360200190a160006000505490505b919050565b602435600435015b60408051918252519081900360200190f35b6100fe600061012e60016100ad565b6100fe600435600781026100f1565b9050610074565b6000805483900390556040805183815290517f4fa5877b6c8d448ebaefa4048625aee504905823a70902d5f9a10a0b6ef0e1279181900360200190a160006000505490506100f156"
+
+CONTRACT_MATH_V2_SOURCE = ("""
+contract Math {
+    uint public counter;
+
+    event Increased(uint value);
+    event Decreased(uint value);
+
+    function increment() public returns (uint) {
+        return increment(1);
+    }
+
+    function increment(uint amt) public returns (uint) {
+        counter += amt;
+        Increased(amt);
+        return counter;
+    }
+
+    function decrement() public returns (uint) {
+        return decrement(1);
+    }
+
+    function decrement(uint amt) public returns (uint) {
+        if (amt > counter) throw;
+        counter -= amt;
+        Decreased(amt);
+        return counter;
+    }
+
+    function add(int a, int b) public returns (int result) {
+        result = a + b;
+        return result;
+    }
+
+    function multiply7(int a) public returns (int result) {
+        result = a * 7;
+        return result;
+    }
+
+    function return13() public returns (int result) {
+        result = 13;
+        return result;
+    }
+}
+""").strip()
+
+CONTRACT_MATH_V2_ABI = json.loads('[{"constant":false,"inputs":[],"name":"return13","outputs":[{"name":"result","type":"int256"}],"type":"function"},{"constant":false,"inputs":[],"name":"decrement","outputs":[{"name":"","type":"uint256"}],"type":"function"},{"constant":false,"inputs":[{"name":"amt","type":"uint256"}],"name":"decrement","outputs":[{"name":"","type":"uint256"}],"type":"function"},{"constant":true,"inputs":[],"name":"counter","outputs":[{"name":"","type":"uint256"}],"type":"function"},{"constant":false,"inputs":[{"name":"amt","type":"uint256"}],"name":"increment","outputs":[{"name":"","type":"uint256"}],"type":"function"},{"constant":false,"inputs":[{"name":"a","type":"int256"},{"name":"b","type":"int256"}],"name":"add","outputs":[{"name":"result","type":"int256"}],"type":"function"},{"constant":false,"inputs":[],"name":"increment","outputs":[{"name":"","type":"uint256"}],"type":"function"},{"constant":false,"inputs":[{"name":"a","type":"int256"}],"name":"multiply7","outputs":[{"name":"result","type":"int256"}],"type":"function"},{"anonymous":false,"inputs":[{"indexed":false,"name":"value","type":"uint256"}],"name":"Increased","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"name":"value","type":"uint256"}],"name":"Decreased","type":"event"}]')  # NOQA
+
+
+@pytest.fixture(scope="session")
+def MATH_V2_CODE():
+    return CONTRACT_MATH_V2_CODE
+
+
+@pytest.fixture(scope="session")
+def MATH_V2_RUNTIME():
+    return CONTRACT_MATH_V2_RUNTIME
+
+
+@pytest.fixture(scope="session")
+def MATH_V2_SOURCE():
+    return CONTRACT_MATH_V2_SOURCE
+
+
+@pytest.fixture(scope="session")
+def MATH_V2_ABI():
+    return CONTRACT_MATH_V2_ABI
+
+
+@pytest.fixture()
+def MATH_V2(MATH_V2_ABI, MATH_V2_CODE, MATH_V2_RUNTIME, MATH_V2_SOURCE):
+    return {
+        'abi': MATH_V2_ABI,
+        'code': MATH_V2_CODE,
+        'code_runtime': MATH_V2_RUNTIME,
+        'source': MATH_V2_SOURCE,
+    }
+
+
+MULTIPLY13_LIBRARY_SOURCE = ("""
 library Library13 {
     function multiply13(uint v) constant returns (uint) {
         return v * 13;
     }
 }
-"""))
+""").strip()
 
 MULTIPLY13_LIBRARY_CODE = "0x6060604052607c8060106000396000f36503059da08ac35060606040526000357c010000000000000000000000000000000000000000000000000000000090048063cdbf9c4214604157603d565b6007565b60556004808035906020019091905050606b565b6040518082815260200191505060405180910390f35b6000600d820290506077565b91905056"
 
@@ -124,13 +205,13 @@ def LIBRARY_13(LIBRARY_13_CODE,
     }
 
 
-MULTIPLY13_CONTRACT_SOURCE = textwrap.dedent(("""
+MULTIPLY13_CONTRACT_SOURCE = ("""
 contract Multiply13 {
     function multiply13(uint v) constant returns (uint) {
         return Library13.multiply13(v);
     }
 }
-"""))
+""").strip()
 
 MULTIPLY13_CONTRACT_CODE = "0x606060405260db8060106000396000f360606040526000357c010000000000000000000000000000000000000000000000000000000090048063cdbf9c42146037576035565b005b604b60048080359060200190919050506061565b6040518082815260200191505060405180910390f35b600073__Library13_____________________________63cdbf9c4283604051827c0100000000000000000000000000000000000000000000000000000000028152600401808281526020019150506020604051808303818660325a03f41560025750505060405180519060200150905060d6565b91905056"
 

--- a/tests/chain-management/test_chain_get_contract.py
+++ b/tests/chain-management/test_chain_get_contract.py
@@ -39,7 +39,7 @@ def math(temp_chain):
 
     math_deploy_txn_hash = Math.deploy()
     math_deploy_txn = web3.eth.getTransaction(math_deploy_txn_hash)
-    math_address = chain.wait.for_contract_address(math_deploy_txn_hash, timeout=30)
+    math_address = chain.wait.for_contract_address(math_deploy_txn_hash)
 
     assert math_deploy_txn['input'] == MATH['code']
     assert web3.eth.getCode(math_address) == MATH['code_runtime']
@@ -57,7 +57,7 @@ def library_13(temp_chain):
 
     library_deploy_txn_hash = Library13.deploy()
     library_deploy_txn = web3.eth.getTransaction(library_deploy_txn_hash)
-    library_13_address = chain.wait.for_contract_address(library_deploy_txn_hash, timeout=30)
+    library_13_address = chain.wait.for_contract_address(library_deploy_txn_hash)
 
     assert library_deploy_txn['input'] == LIBRARY_13['code']
     assert web3.eth.getCode(library_13_address) == LIBRARY_13['code_runtime']
@@ -84,7 +84,7 @@ def multiply_13(temp_chain, library_13):
 
     multiply_13_deploy_txn_hash = LinkedMultiply13.deploy()
     multiply_13_deploy_txn = web3.eth.getTransaction(multiply_13_deploy_txn_hash)
-    multiply_13_address = chain.wait.for_contract_address(multiply_13_deploy_txn_hash, timeout=30)
+    multiply_13_address = chain.wait.for_contract_address(multiply_13_deploy_txn_hash)
 
     assert multiply_13_deploy_txn['input'] == LinkedMultiply13.code
     assert web3.eth.getCode(multiply_13_address) == LinkedMultiply13.code_runtime
@@ -100,7 +100,7 @@ def register_address(temp_chain):
         register_txn_hash = temp_chain.registrar.transact().setAddress(
             'contract/{name}'.format(name=name), value,
         )
-        chain.wait.for_receipt(register_txn_hash, timeout=120)
+        chain.wait.for_receipt(register_txn_hash)
     return _register_address
 
 


### PR DESCRIPTION
See #179 

### What was wrong?

The `Chain.get_contract_factory` function was using the live compiled project assets to build the contract factories.  This caused bytecode verification to fail in certain cases when it should not since bytecode verification was occuring against the live compiled project assets instead of the frozen contract assets from the migration that deployed that contract.

### How was it fixed?

When a project has migrations, the `Chain.get_contract_factory` data will be populated using the following strategy.

1. From the migration in which this contract was last deployed.
2. From the newest migration file that contains this contract.
3. From the project compiled assets.

#### Cute Animal Picture

> put a cute animal picture here.

![halloween-wizard-dog-7617467](https://cloud.githubusercontent.com/assets/824194/18403700/90c64e44-76a3-11e6-9a68-3c9bd8244c36.jpg)
