### PR TITLE
Project scoping fixes - no recompilation of contract code on tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ keystore/
 # Migrations
 migrations/
 !populus/migrations/
+.cache/

--- a/populus/plugin.py
+++ b/populus/plugin.py
@@ -6,7 +6,7 @@ from populus.migrations.migration import (
 from populus.project import Project
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def project(request):
     # This should probably be configurable using the `request` fixture but it's
     # unclear what needs to be configurable.

--- a/populus/plugin.py
+++ b/populus/plugin.py
@@ -17,7 +17,8 @@ def project(request):
     # use pytest cache to preset the sessions project to recently compiled contracts
     contracts = request.config.cache.get(CACHE_KEY_CONTRACTS, None)
     mtime = request.config.cache.get(CACHE_KEY_MTIME, None)
-    project = Project(cached_contracts=contracts, contracts_mtime=mtime)
+    project = Project()
+    project.fill_contracts_cache(contracts, mtime)
     request.config.cache.set(CACHE_KEY_CONTRACTS, project.compiled_contracts)
     request.config.cache.set(CACHE_KEY_MTIME, project.get_source_modification_time())
 

--- a/populus/plugin.py
+++ b/populus/plugin.py
@@ -5,22 +5,21 @@ from populus.migrations.migration import (
 )
 from populus.project import Project
 
-POPULUS_PROJECT_MTIME = "populus/project_mtime"
-POPULUS_PROJECT_CODE = "populus/project_code"
+CACHE_KEY_MTIME = "populus/project/compiled_contracts_mtime"
+CACHE_KEY_CONTRACTS = "populus/project/compiled_contracts"
 
 
 @pytest.fixture(scope="session")
 def project(request):
     # This should probably be configurable using the `request` fixture but it's
     # unclear what needs to be configurable.
-    code = request.config.cache.get(POPULUS_PROJECT_CODE, None)
-    code_mtime = request.config.cache.get(POPULUS_PROJECT_MTIME, None)
-    project = Project()
-    if code is not None and code_mtime is not None:
-        project._cached_compiled_contracts_mtime = code_mtime
-        project._cached_compiled_contracts = code
-    request.config.cache.set(POPULUS_PROJECT_CODE, project.compiled_contracts)
-    request.config.cache.set(POPULUS_PROJECT_MTIME, project._cached_compiled_contracts_mtime)
+
+    # use pytest cache to preset the sessions project to recently compiled contracts
+    contracts = request.config.cache.get(CACHE_KEY_CONTRACTS, None)
+    mtime = request.config.cache.get(CACHE_KEY_MTIME, None)
+    project = Project(cached_contracts=contracts, contracts_mtime=mtime)
+    request.config.cache.set(CACHE_KEY_CONTRACTS, project.compiled_contracts)
+    request.config.cache.set(CACHE_KEY_MTIME, project.get_source_modification_time())
 
     return project
 

--- a/populus/plugin.py
+++ b/populus/plugin.py
@@ -5,12 +5,24 @@ from populus.migrations.migration import (
 )
 from populus.project import Project
 
+POPULUS_PROJECT_HASH = "populus/project_code_hash"
+POPULUS_PROJECT_CODE = "populus/project_code"
+
 
 @pytest.fixture(scope="session")
 def project(request):
     # This should probably be configurable using the `request` fixture but it's
     # unclear what needs to be configurable.
-    return Project()
+    code = request.config.cache.get(POPULUS_PROJECT_CODE, None)
+    code_hash = request.config.cache.get(POPULUS_PROJECT_HASH, None)
+    project = Project()
+    if code is not None and code_hash is not None:
+        project._cached_compiled_contracts_hash = code_hash
+        project._cached_compiled_contracts = code
+    request.config.cache.set(POPULUS_PROJECT_CODE, project.compiled_contracts)
+    request.config.cache.set(POPULUS_PROJECT_HASH, project._cached_compiled_contracts_hash)
+
+    return project
 
 
 @pytest.yield_fixture()

--- a/populus/plugin.py
+++ b/populus/plugin.py
@@ -5,7 +5,7 @@ from populus.migrations.migration import (
 )
 from populus.project import Project
 
-POPULUS_PROJECT_HASH = "populus/project_code_hash"
+POPULUS_PROJECT_MTIME = "populus/project_mtime"
 POPULUS_PROJECT_CODE = "populus/project_code"
 
 
@@ -14,13 +14,13 @@ def project(request):
     # This should probably be configurable using the `request` fixture but it's
     # unclear what needs to be configurable.
     code = request.config.cache.get(POPULUS_PROJECT_CODE, None)
-    code_hash = request.config.cache.get(POPULUS_PROJECT_HASH, None)
+    code_mtime = request.config.cache.get(POPULUS_PROJECT_MTIME, None)
     project = Project()
-    if code is not None and code_hash is not None:
-        project._cached_compiled_contracts_hash = code_hash
+    if code is not None and code_mtime is not None:
+        project._cached_compiled_contracts_mtime = code_mtime
         project._cached_compiled_contracts = code
     request.config.cache.set(POPULUS_PROJECT_CODE, project.compiled_contracts)
-    request.config.cache.set(POPULUS_PROJECT_HASH, project._cached_compiled_contracts_hash)
+    request.config.cache.set(POPULUS_PROJECT_MTIME, project._cached_compiled_contracts_mtime)
 
     return project
 

--- a/populus/project.py
+++ b/populus/project.py
@@ -54,7 +54,8 @@ class Project(object):
 
     def __init__(self, config_file_paths=None, cached_contracts=None, contracts_mtime=None):
         """
-        :param cached_contracts: if supplied with contracts_mtime will become the Project's cache for compiled contracts
+        :param cached_contracts: if supplied with contracts_mtime will become the
+        Project's cache for compiled contracts
         :param contracts_mtime: last modification of supplied contracts
         :return:
         """
@@ -159,8 +160,9 @@ class Project(object):
     @property
     def compiled_contracts(self):
         source_mtime = self.get_source_modification_time()
+        no_cached = self._cached_compiled_contracts_mtime is None
 
-        if self._cached_compiled_contracts_mtime is None or self._cached_compiled_contracts_mtime < source_mtime:
+        if no_cached or self._cached_compiled_contracts_mtime < source_mtime:
             self._cached_compiled_contracts_mtime = source_mtime
             # TODO: the hard coded `optimize=True` should be configurable
             # somehow.

--- a/populus/project.py
+++ b/populus/project.py
@@ -149,8 +149,8 @@ class Project(object):
         ) if len(source_file_paths) > 0 else None
 
     def compiled_contracts_stale(self):
-        no_cached = self._cached_compiled_contracts_mtime is None
-        return no_cached or self._cached_compiled_contracts_mtime < self.get_source_modification_time()
+        return self._cached_compiled_contracts_mtime is None or \
+            self._cached_compiled_contracts_mtime < self.get_source_modification_time()
 
     def fill_contracts_cache(self, contracts, contracts_mtime):
         """

--- a/populus/project.py
+++ b/populus/project.py
@@ -157,13 +157,14 @@ class Project(object):
             in source_file_paths
         ) if len(source_file_paths) > 0 else None
 
+    def compiled_contracts_stale(self):
+        no_cached = self._cached_compiled_contracts_mtime is None
+        return no_cached or self._cached_compiled_contracts_mtime < self.get_source_modification_time()
+
     @property
     def compiled_contracts(self):
-        source_mtime = self.get_source_modification_time()
-        no_cached = self._cached_compiled_contracts_mtime is None
-
-        if no_cached or self._cached_compiled_contracts_mtime < source_mtime:
-            self._cached_compiled_contracts_mtime = source_mtime
+        if self.compiled_contracts_stale():
+            self._cached_compiled_contracts_mtime = self.get_source_modification_time()
             # TODO: the hard coded `optimize=True` should be configurable
             # somehow.
             _, self._cached_compiled_contracts = compile_project_contracts(

--- a/populus/project.py
+++ b/populus/project.py
@@ -52,17 +52,8 @@ class Project(object):
     #: Instance of :class:`populus.utils.Config`, a subclass of ConfigParser
     config = None
 
-    def __init__(self, config_file_paths=None, cached_contracts=None, contracts_mtime=None):
-        """
-        :param cached_contracts: if supplied with contracts_mtime will become the
-        Project's cache for compiled contracts
-        :param contracts_mtime: last modification of supplied contracts
-        :return:
-        """
+    def __init__(self, config_file_paths=None):
         self.load_config(config_file_paths)
-        if cached_contracts is not None and contracts_mtime is not None:
-            self._cached_compiled_contracts_mtime = contracts_mtime
-            self._cached_compiled_contracts = cached_contracts
 
     #
     # Config
@@ -160,6 +151,15 @@ class Project(object):
     def compiled_contracts_stale(self):
         no_cached = self._cached_compiled_contracts_mtime is None
         return no_cached or self._cached_compiled_contracts_mtime < self.get_source_modification_time()
+
+    def fill_contracts_cache(self, contracts, contracts_mtime):
+        """
+        :param contracts: become the Project's cache for compiled contracts
+        :param contracts_mtime: last modification of supplied contracts
+        :return:
+        """
+        self._cached_compiled_contracts_mtime = contracts_mtime
+        self._cached_compiled_contracts = contracts
 
     @property
     def compiled_contracts(self):

--- a/populus/project.py
+++ b/populus/project.py
@@ -52,8 +52,16 @@ class Project(object):
     #: Instance of :class:`populus.utils.Config`, a subclass of ConfigParser
     config = None
 
-    def __init__(self, config_file_paths=None):
+    def __init__(self, config_file_paths=None, cached_contracts=None, contracts_mtime=None):
+        """
+        :param cached_contracts: if supplied with contracts_mtime will become the Project's cache for compiled contracts
+        :param contracts_mtime: last modification of supplied contracts
+        :return:
+        """
         self.load_config(config_file_paths)
+        if cached_contracts is not None and contracts_mtime is not None:
+            self._cached_compiled_contracts_mtime = contracts_mtime
+            self._cached_compiled_contracts = cached_contracts
 
     #
     # Config

--- a/tests/project/test_project_compiled_contracts_property.py
+++ b/tests/project/test_project_compiled_contracts_property.py
@@ -18,3 +18,20 @@ def test_project_compiled_contracts_with_no_default_env(project_dir,
     compiled_contracts_object_id = id(project.compiled_contracts)
 
     assert id(project.compiled_contracts) == compiled_contracts_object_id
+
+
+def test_project_fill_contracts_cache(write_project_file,
+                                      MATH):
+    write_project_file('contracts/Math.sol', MATH['source'])
+    source_mtime = Project().get_source_modification_time()
+
+    project = Project()
+    compiled_contracts_object_id = id(project.compiled_contracts)
+
+    # fill with code from the future -> no recompilation
+    project.fill_contracts_cache(project.compiled_contracts, source_mtime + 10)
+    assert id(project.compiled_contracts) == compiled_contracts_object_id
+
+    # fill with code from the past -> recompilation
+    project.fill_contracts_cache(project.compiled_contracts, source_mtime - 10)
+    assert not id(project.compiled_contracts) == compiled_contracts_object_id


### PR DESCRIPTION
### What was wrong?

see https://github.com/pipermerriam/populus/issues/184

### How was it fixed?

`scope='session'` for `project` fixture and using pytest `request.config.cache` to store the `Project`'s compiled contracts across test runs

#### Cute Animal Picture

![](http://justcuteanimals.com/wp-content/uploads/2016/09/highland-cows-baby-animal-pictures-pics.jpg)

