### PR TITLE
fix deploy command

### DIFF
--- a/populus/cli/deploy_cmd.py
+++ b/populus/cli/deploy_cmd.py
@@ -137,12 +137,13 @@ def deploy(ctx, chain_name, deploy_from, contracts_to_deploy):
         )
         click.echo(starting_msg)
 
-        for contract_name, contract_factory in deploy_order.items():
+        for contract_name, _ in deploy_order.items():
             link_dependencies = {
                 contract_name: contract.address
                 for contract_name, contract
                 in deployed_contracts.items()
             }
+            contract_factory = chain.contract_factories[contract_name]
 
             # Check if we already have an existing deployed version of that
             # contract (via the registry).  For each of these, prompt the user


### PR DESCRIPTION
### What was wrong?

The `deploy` command is broken.  It is treating a dictionary of contract data as if it was a ContractFactory instance.

### How was it fixed?

Use a contract factory.

#### Cute Animal Picture

> put a cute animal picture here.

![682 x600 otc pets wizard silo](https://cloud.githubusercontent.com/assets/824194/18748295/3096c7b8-8104-11e6-95bc-9757f8a91802.jpg)
