### PR TITLE
Fix how link-dependencies is handled in deploy command

### DIFF
--- a/populus/cli/deploy_cmd.py
+++ b/populus/cli/deploy_cmd.py
@@ -90,8 +90,7 @@ def deploy(ctx, chain_name, deploy_from, contracts_to_deploy):
                     ', '.join(sorted(compiled_contracts.keys())),
                 )
             )
-            click.echo(unknown_contracts_message, err=True)
-            click.exit(1)
+            raise click.ClickException(unknown_contracts_message)
     else:
         # prompt the user to select the desired contracts they want to deploy.
         # Potentially display the currently deployed status.

--- a/populus/migrations/registrar.py
+++ b/populus/migrations/registrar.py
@@ -142,11 +142,7 @@ def get_contract_from_registrar(chain,
 
     expected_runtime = link_bytecode(
         contract_factory.code_runtime,
-        **{
-            contract_name: contract.address
-            for contract_name, contract
-            in link_dependencies.items()
-        }
+        **link_dependencies,
     )
     actual_runtime = web3.eth.getCode(contract_address)
 

--- a/populus/migrations/registrar.py
+++ b/populus/migrations/registrar.py
@@ -142,7 +142,7 @@ def get_contract_from_registrar(chain,
 
     expected_runtime = link_bytecode(
         contract_factory.code_runtime,
-        **link_dependencies,
+        **link_dependencies
     )
     actual_runtime = web3.eth.getCode(contract_address)
 


### PR DESCRIPTION
### What was wrong?

The `get_contract_from_registrar` helper function expecting `link_dependencies` in the same way that the remainder of the app used it.

### How was it fixed?

Changed it to just be a direct mapping from library name to library address.

#### Cute Animal Picture

> put a cute animal picture here.

![dog_costumes___wizard_of_oz__02___glinda_by_freakyfluff-d66lxap](https://cloud.githubusercontent.com/assets/824194/18921635/caa2762e-8562-11e6-851f-4e217e3810e5.jpg)
