### PR TITLE
Add polling interval to the wait API

### DIFF
--- a/docs/chain.rst
+++ b/docs/chain.rst
@@ -340,40 +340,44 @@ contracts.
 Waiting for Things
 ------------------
 
-Each chain object exposes the following API through a property ``chain.wait``
+Each chain object exposes the following API through a property ``chain.wait``.
+The ``timeout`` parameter determines how long this will block before raising a
+``gevent.Timeout`` exception.  The ``poll_interval`` determines how long it
+should wait between polling.  If ``poll_interval == None`` then
+``random.random()`` will be used to determine the poling interval.
 
 
-.. py:method:: Chain.wait.for_contract_address(txn_hash, timeout=120)
+.. py:method:: Chain.wait.for_contract_address(txn_hash, timeout=120, poll_interval=None)
 
     Blocks for up to ``timeout`` seconds returning the contract address from the
     transaction receipt for the given ``txn_hash``.
 
 
-.. py:method:: Chain.wait.for_receipt(txn_hash, timeout=120)
+.. py:method:: Chain.wait.for_receipt(txn_hash, timeout=120, poll_interval=None)
 
     Blocks for up to ``timeout`` seconds returning the transaction receipt for
     the given ``txn_hash``.
 
 
-.. py:method:: Chain.wait.for_block(block_number=1, timeout=120)
+.. py:method:: Chain.wait.for_block(block_number=1, timeout=120, poll_interval=None)
 
     Blocks for up to ``timeout`` seconds waiting until the highest block on the
     current chain is at least ``block_number``.
 
 
-.. py:method:: Chain.wait.for_unlock(account=web3.eth.coinbase, timeout=120)
+.. py:method:: Chain.wait.for_unlock(account=web3.eth.coinbase, timeout=120, poll_interval=None)
 
     Blocks for up to ``timeout`` seconds waiting until the account specified by
     ``account`` is unlocked.  If ``account`` is not provided,
     ``web3.eth.coinbase`` will be used.
 
 
-.. py:method:: Chain.wait.for_peers(peer_count=1, timeout=120)
+.. py:method:: Chain.wait.for_peers(peer_count=1, timeout=120, poll_interval=None)
 
     Blocks for up to ``timeout`` seconds waiting for the client to have at
     least ``peer_count`` peer connections.
 
 
-.. py:method:: Chain.wait.for_syncing(timeout=120)
+.. py:method:: Chain.wait.for_syncing(timeout=120, poll_interval=None)
 
     Blocks for up to ``timeout`` seconds waiting the chain to begin syncing.

--- a/populus/utils/wait.py
+++ b/populus/utils/wait.py
@@ -6,17 +6,20 @@ from web3.providers.rpc import TestRPCProvider
 from .empty import empty
 
 
-def wait_for_transaction_receipt(web3, txn_hash, timeout=120):
+def wait_for_transaction_receipt(web3, txn_hash, timeout=120, poll_interval=None):
     with gevent.Timeout(timeout):
         while True:
             txn_receipt = web3.eth.getTransactionReceipt(txn_hash)
             if txn_receipt is not None:
                 break
-            gevent.sleep(random.random())
+            if poll_interval is None:
+                gevent.sleep(random.random())
+            else:
+                gevent.sleep(poll_interval)
     return txn_receipt
 
 
-def wait_for_block_number(web3, block_number=1, timeout=120):
+def wait_for_block_number(web3, block_number=1, timeout=120, poll_interval=None):
 
     with gevent.Timeout(timeout):
         while web3.eth.blockNumber < block_number:
@@ -24,11 +27,14 @@ def wait_for_block_number(web3, block_number=1, timeout=120):
                 web3._requestManager.request_blocking("evm_mine", [])
                 gevent.sleep(0)
             else:
-                gevent.sleep(random.random())
+                if poll_interval is None:
+                    gevent.sleep(random.random())
+                else:
+                    gevent.sleep(poll_interval)
     return web3.eth.getBlock(block_number)
 
 
-def wait_for_unlock(web3, account=None, timeout=120):
+def wait_for_unlock(web3, account=None, timeout=120, poll_interval=None):
     from .accounts import is_account_locked
 
     if account is None:
@@ -36,67 +42,122 @@ def wait_for_unlock(web3, account=None, timeout=120):
 
     with gevent.Timeout(timeout):
         while is_account_locked(web3, account):
-            gevent.sleep(random.random())
+            if poll_interval is None:
+                gevent.sleep(random.random())
+            else:
+                gevent.sleep(poll_interval)
+    return account
 
 
-def wait_for_peers(web3, peer_count=1, timeout=120):
+def wait_for_peers(web3, peer_count=1, timeout=120, poll_interval=None):
     with gevent.Timeout(timeout):
         while web3.net.peerCount < peer_count:
             gevent.sleep(random.random())
 
 
-def wait_for_syncing(web3, timeout=120):
+def wait_for_syncing(web3, timeout=120, poll_interval=None):
     start_block = web3.eth.blockNumber
     with gevent.Timeout(timeout):
         while not web3.eth.syncing and web3.eth.blockNumber == start_block:
-            gevent.sleep(random.random())
+            if poll_interval is None:
+                gevent.sleep(random.random())
+            else:
+                gevent.sleep(poll_interval)
+    return web3.eth.syncing
 
 
 class Wait(object):
     web3 = None
     timeout = 120
+    poll_interval = None
 
-    def __init__(self, web3, timeout=empty):
+    def __init__(self, web3, timeout=empty, poll_interval=empty):
         self.web3 = web3
         if timeout is not empty:
             self.timeout = timeout
+        if poll_interval is not empty:
+            self.poll_interval = poll_interval
 
-    def for_contract_address(self, txn_hash, timeout=empty):
-        txn_receipt = self.for_receipt(txn_hash, timeout=timeout)
+    def for_contract_address(self, txn_hash, timeout=empty, poll_interval=empty):
+        kwargs = {}
+        if timeout is not empty:
+            kwargs['timeout'] = timeout
+        if poll_interval is not empty:
+            kwargs['poll_interval'] = poll_interval
+
+        kwargs.setdefault('timeout', self.timeout)
+        kwargs.setdefault('poll_interval', self.poll_interval)
+
+        txn_receipt = self.for_receipt(txn_hash, **kwargs)
         return txn_receipt['contractAddress']
 
-    def for_receipt(self, txn_hash, timeout=empty):
-        if timeout is empty:
-            timeout = self.timeout
-
-        return wait_for_transaction_receipt(self.web3, txn_hash, timeout=timeout)
-
-    def for_block(self, block_number=empty, timeout=empty):
+    def for_receipt(self, txn_hash, timeout=empty, poll_interval=empty):
         kwargs = {}
+
+        if timeout is not empty:
+            kwargs['timeout'] = timeout
+        if poll_interval is not empty:
+            kwargs['poll_interval'] = poll_interval
+
+        kwargs.setdefault('timeout', self.timeout)
+        kwargs.setdefault('poll_interval', self.poll_interval)
+
+        return wait_for_transaction_receipt(self.web3, txn_hash, **kwargs)
+
+    def for_block(self, block_number=empty, timeout=empty, poll_interval=empty):
+        kwargs = {}
+
         if block_number is not empty:
             kwargs['block_number'] = block_number
-        if timeout is empty:
-            timeout = self.timeout
+        if timeout is not empty:
+            kwargs['timeout'] = timeout
+        if poll_interval is not empty:
+            kwargs['poll_interval'] = poll_interval
 
-        return wait_for_block_number(self.web3, timeout=timeout, **kwargs)
+        kwargs.setdefault('timeout', self.timeout)
+        kwargs.setdefault('poll_interval', self.poll_interval)
 
-    def for_unlock(self, account=empty, timeout=empty):
+        return wait_for_block_number(self.web3, **kwargs)
+
+    def for_unlock(self, account=empty, timeout=empty, poll_interval=empty):
         kwargs = {}
+
         if account is not empty:
             kwargs['account'] = account
-        if timeout is empty:
-            timeout = self.timeout
-        return wait_for_unlock(self.web3, timeout=timeout, **kwargs)
+        if timeout is not empty:
+            kwargs['timeout'] = timeout
+        if poll_interval is not empty:
+            kwargs['poll_interval'] = poll_interval
 
-    def for_peers(self, peer_count=empty, timeout=empty):
+        kwargs.setdefault('timeout', self.timeout)
+        kwargs.setdefault('poll_interval', self.poll_interval)
+
+        return wait_for_unlock(self.web3, **kwargs)
+
+    def for_peers(self, peer_count=empty, timeout=empty, poll_interval=empty):
         kwargs = {}
+
         if peer_count is not empty:
             kwargs['peer_count'] = peer_count
-        if timeout is empty:
-            timeout = self.timeout
-        return wait_for_peers(self.web3, timeout=timeout, **kwargs)
+        if timeout is not empty:
+            kwargs['timeout'] = timeout
+        if poll_interval is not empty:
+            kwargs['poll_interval'] = poll_interval
 
-    def for_syncing(self, timeout=empty):
-        if timeout is empty:
-            timeout = self.timeout
-        return wait_for_syncing(self.web3, timeout=timeout)
+        kwargs.setdefault('timeout', self.timeout)
+        kwargs.setdefault('poll_interval', self.poll_interval)
+
+        return wait_for_peers(self.web3, **kwargs)
+
+    def for_syncing(self, timeout=empty, poll_interval=empty):
+        kwargs = {}
+
+        if timeout is not empty:
+            kwargs['timeout'] = timeout
+        if poll_interval is not empty:
+            kwargs['poll_interval'] = poll_interval
+
+        kwargs.setdefault('timeout', self.timeout)
+        kwargs.setdefault('poll_interval', self.poll_interval)
+
+        return wait_for_syncing(self.web3, **kwargs)


### PR DESCRIPTION
### What was wrong?

The `chain.wait` API ends up hammering the RPC node once you have a few things happening concurrently.

### How was it fixed?

Added a new parameter `polling_interval` which can be used to control how aggressively it polls.


#### Cute Animal Picture

> put a cute animal picture here.

![wizard-of-oz-wicked-witch-of-the-west-witch-dog-costume-bc-806125](https://cloud.githubusercontent.com/assets/824194/18972983/8c722b78-8658-11e6-966c-9f3c8ed369c3.jpg)
