### PR TITLE
Support old txn-receipt functionality

### DIFF
--- a/populus/utils/wait.py
+++ b/populus/utils/wait.py
@@ -10,7 +10,7 @@ def wait_for_transaction_receipt(web3, txn_hash, timeout=120, poll_interval=None
     with gevent.Timeout(timeout):
         while True:
             txn_receipt = web3.eth.getTransactionReceipt(txn_hash)
-            if txn_receipt is not None:
+            if txn_receipt is not None and txn_receipt['blockHash'] is not None:
                 break
             if poll_interval is None:
                 gevent.sleep(random.random())


### PR DESCRIPTION
### What was wrong?

In a previous life 

### How was it fixed?

Changed the `wait_for_transaction_receipt` function to check that both the `txn_receipt` is not `None` and that the `blockHash` key is also not `None`.

#### Cute Animal Picture


![b77e7b3c00acfc79224ad7c5bcaf6e4b](https://cloud.githubusercontent.com/assets/824194/19046529/0eec7b94-895b-11e6-9642-9bf77e34bf01.jpg)

