### PR TITLE
Allow for custom contracts_dir from config

### DIFF
--- a/populus/compilation.py
+++ b/populus/compilation.py
@@ -2,7 +2,6 @@ import os
 import json
 
 from populus.utils.filesystem import (
-    get_contracts_dir,
     get_compiled_contracts_file_path,
     recursive_find_files,
 )
@@ -14,8 +13,8 @@ from solc.exceptions import (
 )
 
 
-def find_project_contracts(project_dir):
-    contracts_dir = get_contracts_dir(project_dir)
+def find_project_contracts(project_dir, contracts_rel_dir):
+    contracts_dir = os.path.join(project_dir, contracts_rel_dir)
 
     return tuple(
         os.path.relpath(p) for p in recursive_find_files(contracts_dir, "*.sol")
@@ -35,9 +34,9 @@ def write_compiled_sources(project_dir, compiled_sources):
     return compiled_contract_path
 
 
-def compile_project_contracts(project_dir, **compiler_kwargs):
+def compile_project_contracts(project_dir, contracts_dir, **compiler_kwargs):
     compiler_kwargs.setdefault('output_values', ['bin', 'bin-runtime', 'abi'])
-    contract_source_paths = find_project_contracts(project_dir)
+    contract_source_paths = find_project_contracts(project_dir, contracts_dir)
     try:
         compiled_sources = compile_files(contract_source_paths, **compiler_kwargs)
     except ContractsNotFound:
@@ -46,9 +45,10 @@ def compile_project_contracts(project_dir, **compiler_kwargs):
     return contract_source_paths, compiled_sources
 
 
-def compile_and_write_contracts(project_dir, **compiler_kwargs):
+def compile_and_write_contracts(project_dir, contracts_dir, **compiler_kwargs):
     contract_source_paths, compiled_sources = compile_project_contracts(
         project_dir,
+        contracts_dir,
         **compiler_kwargs
     )
 

--- a/populus/compilation.py
+++ b/populus/compilation.py
@@ -4,6 +4,7 @@ import json
 from populus.utils.filesystem import (
     get_compiled_contracts_file_path,
     recursive_find_files,
+    DEFAULT_CONTRACTS_DIR
 )
 from solc import (
     compile_files,
@@ -13,7 +14,7 @@ from solc.exceptions import (
 )
 
 
-def find_project_contracts(project_dir, contracts_rel_dir):
+def find_project_contracts(project_dir, contracts_rel_dir=DEFAULT_CONTRACTS_DIR):
     contracts_dir = os.path.join(project_dir, contracts_rel_dir)
 
     return tuple(

--- a/populus/project.py
+++ b/populus/project.py
@@ -114,7 +114,11 @@ class Project(object):
     @property
     @relpath
     def contracts_dir(self):
-        return get_contracts_dir(self.project_dir)
+        if self.config.has_option('populus', 'contracts_dir'):
+            s = self.config.get('populus', 'contracts_dir')
+            return s
+        else:
+            return get_contracts_dir(self.project_dir)
 
     @property
     @relpath

--- a/populus/project.py
+++ b/populus/project.py
@@ -115,8 +115,7 @@ class Project(object):
     @relpath
     def contracts_dir(self):
         if self.config.has_option('populus', 'contracts_dir'):
-            s = self.config.get('populus', 'contracts_dir')
-            return s
+            return self.config.get('populus', 'contracts_dir')
         else:
             return get_contracts_dir(self.project_dir)
 
@@ -137,7 +136,7 @@ class Project(object):
     _cached_compiled_contracts = None
 
     def get_source_file_hash(self):
-        source_file_paths = find_project_contracts(self.project_dir)
+        source_file_paths = find_project_contracts(self.project_dir, self.contracts_dir)
         return hashlib.md5(b''.join(
             open(source_file_path, 'rb').read()
             for source_file_path
@@ -145,7 +144,7 @@ class Project(object):
         )).hexdigest()
 
     def get_source_modification_time(self):
-        source_file_paths = find_project_contracts(self.project_dir)
+        source_file_paths = find_project_contracts(self.project_dir, self.contracts_dir)
         return max(
             os.path.getmtime(source_file_path)
             for source_file_path
@@ -173,6 +172,7 @@ class Project(object):
             # somehow.
             _, self._cached_compiled_contracts = compile_project_contracts(
                 project_dir=self.project_dir,
+                contracts_dir=self.contracts_dir,
                 optimize=True,
             )
         return self._cached_compiled_contracts

--- a/populus/utils/cli.py
+++ b/populus/utils/cli.py
@@ -465,7 +465,11 @@ def compile_project_contracts(project, optimize=True):
     click.echo("============ Compiling ==============")
     click.echo("> Loading source files from: ./{0}\n".format(project.contracts_dir))
 
-    result = compile_and_write_contracts(project.project_dir, optimize=optimize)
+    result = compile_and_write_contracts(
+        project.project_dir,
+        project.contracts_dir,
+        optimize=optimize
+    )
     contract_source_paths, compiled_sources, output_file_path = result
 
     click.echo("> Found {0} contract source files".format(

--- a/populus/utils/filesystem.py
+++ b/populus/utils/filesystem.py
@@ -5,6 +5,7 @@ import fnmatch
 import tempfile
 import contextlib
 import functools
+import errno
 
 
 if sys.version_info.major == 2:
@@ -46,6 +47,16 @@ def remove_dir_if_exists(path):
         shutil.rmtree(path)
         return True
     return False
+
+
+def mkdir(path):
+    try:
+        os.makedirs(path)
+    except OSError as exc:  # Python >2.5
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise
 
 
 DEFAULT_CONTRACTS_DIR = "./contracts/"

--- a/populus/utils/filesystem.py
+++ b/populus/utils/filesystem.py
@@ -48,11 +48,11 @@ def remove_dir_if_exists(path):
     return False
 
 
-CONTRACTS_DIR = "./contracts/"
+DEFAULT_CONTRACTS_DIR = "./contracts/"
 
 
 def get_contracts_dir(project_dir):
-    contracts_dir = os.path.join(project_dir, CONTRACTS_DIR)
+    contracts_dir = os.path.join(project_dir, DEFAULT_CONTRACTS_DIR)
     return os.path.abspath(contracts_dir)
 
 

--- a/tests/compile/test_find_project_contracts.py
+++ b/tests/compile/test_find_project_contracts.py
@@ -1,9 +1,10 @@
 import os
 
 from populus.compilation import find_project_contracts
+from populus.utils.filesystem import mkdir
 
 
-def test_gets_correct_files(project_dir, write_project_file):
+def test_gets_correct_files_default_dir(project_dir, write_project_file):
     file_names = find_project_contracts(project_dir)
 
     should_match = {
@@ -15,6 +16,34 @@ def test_gets_correct_files(project_dir, write_project_file):
         'contracts/BackedUpContract.sol.bak',
         'contracts/Swapfile.sol.swp',
         'contracts/not-contract.txt',
+    }
+
+    for filename in should_match:
+        write_project_file(filename)
+
+    for filename in should_not_match:
+        write_project_file(filename)
+
+    for file_name in file_names:
+        assert os.path.exists(file_name)
+        assert os.path.basename(file_name) in should_match
+        assert os.path.basename(file_name) not in should_not_match
+
+
+def test_gets_correct_files_custom_dir(project_dir, write_project_file):
+    custom_dir = "my_custom_dir"
+    mkdir(os.path.join(project_dir, custom_dir))
+    file_names = find_project_contracts(project_dir, custom_dir)
+
+    should_match = {
+        '{}/SolidityContract.sol'.format(custom_dir),
+        '{}/AnotherFile.sol'.format(custom_dir),
+    }
+
+    should_not_match = {
+        '{}/BackedUpContract.sol.bak'.format(custom_dir),
+        '{}/Swapfile.sol.swp'.format(custom_dir),
+        '{}/not-contract.txt'.format(custom_dir),
     }
 
     for filename in should_match:

--- a/tests/compile/test_solidity_contract_with_imports.py
+++ b/tests/compile/test_solidity_contract_with_imports.py
@@ -4,6 +4,7 @@ import json
 
 import os
 
+from populus.utils.filesystem import DEFAULT_CONTRACTS_DIR
 from populus.compilation import (
     compile_and_write_contracts,
 )
@@ -45,7 +46,7 @@ def test_compilation(project_dir, write_project_file):
     write_project_file('contracts/ContractB.sol', CONTRACT_B_SOURCE)
     write_project_file('contracts/ContractC.sol', CONTRACT_C_SOURCE)
 
-    source_paths, compiled_sources, outfile_path = compile_and_write_contracts(project_dir)
+    source_paths, compiled_sources, outfile_path = compile_and_write_contracts(project_dir, DEFAULT_CONTRACTS_DIR)
 
     with open(outfile_path) as outfile:
         compiled_contract_data = json.load(outfile)


### PR DESCRIPTION
### What was wrong?
I need a way to specify a custom contracts directory. I believe users need the ability to do so.


### How was it fixed?

Users can now specify a custom `contracts_dir` from inside the
`populus.ini` configuration file.

```ini
[populus]
contracts_dir=smart_contracts
```


#### Cute Animal Picture

![image carsten_schlatt_rotkehlchen](https://cloud.githubusercontent.com/assets/1658405/19500323/4b5ed5ca-959c-11e6-8118-12f6aa41c1eb.jpg)

