### PR TITLE
Add logs/ and migrations/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,9 @@ chaindata/
 genesis.json
 keystore/
 
+# Test remnants
+logs/
+migrations/
+
 # pytest
 .cache/


### PR DESCRIPTION
After running tests I get these directories which litter the working directory. I think it would be nice to have them in `.gitignore`.

