### PR TITLE
Fix JSONFile backend when working with an empty registry

### DIFF
--- a/populus/assets/defaults.config.json
+++ b/populus/assets/defaults.config.json
@@ -11,8 +11,10 @@
       "contracts": {
         "backends": {
           "JSONFile": {
-            "$ref": "contracts.backends.JSONFile",
-            "$ref": "contracts.backends.InstalledPackagesBackend"
+            "$ref": "contracts.backends.JSONFile"
+          },
+          "InstalledPackages": {
+            "$ref": "contracts.backends.InstalledPackages"
           }
         }
       }
@@ -27,8 +29,10 @@
       "contracts": {
         "backends": {
           "JSONFile": {
-            "$ref": "contracts.backends.JSONFile",
-            "$ref": "contracts.backends.InstalledPackagesBackend"
+            "$ref": "contracts.backends.JSONFile"
+          },
+          "InstalledPackages": {
+            "$ref": "contracts.backends.InstalledPackages"
           }
         }
       }
@@ -43,8 +47,10 @@
       "contracts": {
         "backends": {
           "Memory": {
-            "$ref": "contracts.backends.Memory",
-            "$ref": "contracts.backends.InstalledPackagesBackend"
+            "$ref": "contracts.backends.Memory"
+          },
+          "InstalledPackages": {
+            "$ref": "contracts.backends.InstalledPackages"
           }
         }
       }
@@ -59,8 +65,10 @@
       "contracts": {
         "backends": {
           "Memory": {
-            "$ref": "contracts.backends.Memory",
-            "$ref": "contracts.backends.InstalledPackagesBackend"
+            "$ref": "contracts.backends.Memory"
+          },
+          "InstalledPackages": {
+            "$ref": "contracts.backends.InstalledPackages"
           }
         }
       }
@@ -75,8 +83,10 @@
       "contracts": {
         "backends": {
           "Memory": {
-            "$ref": "contracts.backends.Memory",
-            "$ref": "contracts.backends.InstalledPackagesBackend"
+            "$ref": "contracts.backends.Memory"
+          },
+          "InstalledPackages": {
+            "$ref": "contracts.backends.InstalledPackages"
           }
         }
       }
@@ -85,7 +95,7 @@
   "contracts": {
     "backends": {
       "InstalledPackages": {
-        "class": "populus.providers.backends.installed_packages.InstalledPackagesBackend",
+        "class": "populus.contracts.backends.installed_packages.InstalledPackagesBackend",
         "priority": 20
       },
       "JSONFile": {

--- a/populus/assets/defaults.config.json
+++ b/populus/assets/defaults.config.json
@@ -11,7 +11,8 @@
       "contracts": {
         "backends": {
           "JSONFile": {
-            "$ref": "contracts.backends.JSONFile"
+            "$ref": "contracts.backends.JSONFile",
+            "$ref": "contracts.backends.InstalledPackagesBackend"
           }
         }
       }
@@ -26,7 +27,8 @@
       "contracts": {
         "backends": {
           "JSONFile": {
-            "$ref": "contracts.backends.JSONFile"
+            "$ref": "contracts.backends.JSONFile",
+            "$ref": "contracts.backends.InstalledPackagesBackend"
           }
         }
       }
@@ -41,7 +43,8 @@
       "contracts": {
         "backends": {
           "Memory": {
-            "$ref": "contracts.backends.Memory"
+            "$ref": "contracts.backends.Memory",
+            "$ref": "contracts.backends.InstalledPackagesBackend"
           }
         }
       }
@@ -56,7 +59,8 @@
       "contracts": {
         "backends": {
           "Memory": {
-            "$ref": "contracts.backends.Memory"
+            "$ref": "contracts.backends.Memory",
+            "$ref": "contracts.backends.InstalledPackagesBackend"
           }
         }
       }
@@ -71,7 +75,8 @@
       "contracts": {
         "backends": {
           "Memory": {
-            "$ref": "contracts.backends.Memory"
+            "$ref": "contracts.backends.Memory",
+            "$ref": "contracts.backends.InstalledPackagesBackend"
           }
         }
       }

--- a/populus/cli/package_cmd.py
+++ b/populus/cli/package_cmd.py
@@ -2,6 +2,10 @@ import click
 import json
 import os
 
+from populus.utils.functional import (
+    compose,
+    cast_return_to_dict,
+)
 from populus.utils.filesystem import (
     ensure_path_exists,
 )
@@ -38,6 +42,13 @@ def package_cmd(ctx):
 
 def split_on_commas(values):
     return [value.strip() for value in values.split(',') if value]
+
+
+@cast_return_to_dict
+def split_on_colons(values):
+    for kv in values:
+        key, _, value = kv.partition(':')
+        yield key, value
 
 
 @package_cmd.command('init')
@@ -114,7 +125,7 @@ def package_init(ctx):
 
     package_manifest['links'] = click.prompt(
         'Links',
-        value_proc=split_on_commas,
+        value_proc=compose(split_on_commas, split_on_colons),
         default=package_manifest.get('links', {}),
     )
 

--- a/populus/contracts/backends/filesystem.py
+++ b/populus/contracts/backends/filesystem.py
@@ -74,7 +74,7 @@ class JSONFileBackend(BaseContractBackend):
         registrar_data = self.registrar_data
         matching_chain_definitions = get_matching_chain_definitions(
             self.chain.web3,
-            registrar_data['deployments'],
+            registrar_data.get('deployments', {}),
         )
         sort_key_fn = functools.partial(chain_definition_sort_key, self.chain.web3)
         ordered_matching_chain_definitions = tuple(sorted(

--- a/populus/packages/build.py
+++ b/populus/packages/build.py
@@ -67,7 +67,7 @@ def construct_release_lockfile(project,
 
     contract_types_names_from_deployments = {
         contract_instance['contract_type']
-        for deployed_instances in deployments
+        for deployed_instances in deployments.values()
         for contract_instance in deployed_instances.values()
         if is_contract_name(contract_instance['contract_type'])
     }
@@ -89,7 +89,7 @@ def construct_deployments(project, chain_names, contract_instance_names):
     for chain_name in chain_names:
         with project.get_chain(chain_name) as chain:
             chain_definition = get_chain_definition(chain.web3)
-            provider = chain.contract_provider
+            provider = chain.store.provider
             deployed_contract_instances = construct_deployments_object(
                 provider,
                 contract_instance_names,

--- a/tests/contract-backends/test_json_file_backend.py
+++ b/tests/contract-backends/test_json_file_backend.py
@@ -4,6 +4,7 @@ import json
 import os
 
 from populus.config import Config
+from populus.contracts.exceptions import NoKnownAddress
 from populus.contracts.backends.filesystem import JSONFileBackend
 
 from populus.utils.chains import (
@@ -69,3 +70,8 @@ def test_getting_an_address(project_dir, backend, web3):
 
     address = backend.get_contract_address('some-key')
     assert address == '0xd3cda913deb6f67967b99d67acdfa1712c293601'
+
+
+def test_getting_an_unknown_address(project_dir, backend, web3):
+    with pytest.raises(NoKnownAddress):
+        backend.get_contract_address('some-key')


### PR DESCRIPTION
### What was wrong?

The JSONFile backend fails when the registry is empty.

### How was it fixed?

Change how the deployments are looked up.

#### Cute Animal Picture

> put a cute animal picture here.

![4850dc58f8feaf07473c1d790615ddb1](https://cloud.githubusercontent.com/assets/824194/22600876/c5f122dc-e9f9-11e6-9f68-766e8fbc73d7.jpeg)
