### PR TITLE
remove web3.utils dependencies

### DIFF
--- a/populus/utils/cli.py
+++ b/populus/utils/cli.py
@@ -88,7 +88,7 @@ def select_account(chain):
 
     account_choice = click.prompt(
         pick_account_message,
-        default=chain.web3.eth.defaultAccount,
+        default=chain.web3.eth.defaultAccount or chain.web3.eth.coinbase,
     )
 
     if account_choice in set(all_accounts):
@@ -216,7 +216,7 @@ def configure_chain(project, chain_name):
         choose_default_account_msg = (
             "This chain will default to sending transactions from "
             "{0}.  Would you like to set a different default "
-            "account?".format(web3.eth.defaultAccount)
+            "account?".format(web3.eth.defaultAccount or web3.eth.coinbase)
         )
         if click.confirm(choose_default_account_msg, default=True):
             default_account = select_account(chain)
@@ -272,9 +272,9 @@ def deploy_contract_and_verify(chain,
     if base_contract_factory is None:
         base_contract_factory = chain.contract_factories[contract_name]
 
-    if is_account_locked(web3, web3.eth.defaultAccount):
+    if is_account_locked(web3, web3.eth.defaultAccount or web3.eth.coinbase):
         try:
-            chain.wait.for_unlock(web3.eth.defaultAccount, 5)
+            chain.wait.for_unlock(web3.eth.defaultAccount or web3.eth.coinbase, 5)
         except Timeout:
             default_account = select_account(chain)
             if is_account_locked(web3, default_account):

--- a/populus/utils/types.py
+++ b/populus/utils/types.py
@@ -1,13 +1,9 @@
 import re
 
-
 from eth_utils import (
     is_string,
     is_boolean,
     is_number,
-)
-
-from web3.utils.string import (
     force_text,
 )
 

--- a/tests/cli/test_request_account_unlock_helper_fn.py
+++ b/tests/cli/test_request_account_unlock_helper_fn.py
@@ -2,9 +2,11 @@ import pytest
 import click
 from click.testing import CliRunner
 
-from geth.accounts import create_new_account
+from eth_utils import (
+    force_text,
+)
 
-from web3.utils.string import force_text
+from geth.accounts import create_new_account
 
 from populus.utils.accounts import (
     is_account_locked,

--- a/tests/migrations/test_receipt_processing.py
+++ b/tests/migrations/test_receipt_processing.py
@@ -1,4 +1,4 @@
-from web3.utils.encoding import (
+from eth_utils import (
     encode_hex,
 )
 from populus.migrations.deferred import (


### PR DESCRIPTION
### What was wrong?

Leftover dependencies on `web3.utils`

### How was it fixed?

Removed the imports in favor of `eth_utils` helpers.

#### Cute Animal Picture

> put a cute animal picture here.

![squirrel funny pic](https://cloud.githubusercontent.com/assets/824194/23186522/74b20822-f855-11e6-9d19-f9c9c4fb7afb.jpeg)
