### PR TITLE
anyconfig 0.9.0 compat

### DIFF
--- a/populus/config/base.py
+++ b/populus/config/base.py
@@ -70,7 +70,7 @@ class Config(object):
         if config_class is None:
             config_class = Config
         try:
-            return config_class(self.resolve(self[key]), parent=self)
+            return config_class(copy.deepcopy(self.resolve(self[key])), parent=self)
         except KeyError:
             return config_class(get_empty_config(), parent=self)
 

--- a/populus/config/base.py
+++ b/populus/config/base.py
@@ -34,7 +34,7 @@ class Config(object):
     def __init__(self, config=None, parent=None, schema=None):
         if config is None:
             config = get_empty_config()
-        elif isinstance(config, dict):
+        elif isinstance(config, dict) and hasattr(anyconfig, 'to_container'):
             config = anyconfig.to_container(config)
 
         self._wrapped = config

--- a/populus/utils/config.py
+++ b/populus/utils/config.py
@@ -42,7 +42,10 @@ get_default_project_config_file_path = get_json_config_file_path
 
 
 def get_empty_config():
-    empty_config = anyconfig.to_container({})
+    if hasattr(anyconfig, 'to_container'):
+        empty_config = anyconfig.to_container({})
+    else:
+        empty_config = {}
     return empty_config
 
 

--- a/tests/config-objects/test_base_config_object.py
+++ b/tests/config-objects/test_base_config_object.py
@@ -17,6 +17,10 @@ def test_checking_config_truthyness():
     assert bool(non_empty_config) is True
 
 
+@pytest.mark.skipif(
+    not hasattr(anyconfig, 'to_container'),
+    reason="`to_container` removed in latest versions of anyconfig"
+)
 def test_checking_config_equality():
     config = Config({'a': 1, 'b': 2})
     other_config = Config({'a': 1, 'b': 2})


### PR DESCRIPTION
### What was wrong?

Anyconfig removed the `anyconfig.to_container` API.

### How was it fixed?

Only use this api conditionally.

#### Cute Animal Picture

> put a cute animal picture here.

![o-baby-sloth-900](https://cloud.githubusercontent.com/assets/824194/23720826/2204f568-03fd-11e7-8540-a28b7332fafa.jpeg)
