### PR TITLE
fix typo in project.config setter

### DIFF
--- a/populus/project.py
+++ b/populus/project.py
@@ -123,7 +123,7 @@ class Project(object):
     @config.setter
     def config(self, value):
         if isinstance(value, Config):
-            self._config_cache = Config
+            self._config_cache = value
         else:
             self._project_config = value
             config_version = self._project_config['version']

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ readme = open(os.path.join(DIR, 'README.md')).read()
 
 setup(
     name='populus',
-    version="1.6.3",
+    version="1.6.4-beta.1",
     description="""Ethereum Development Framework""",
     long_description=readme,
     author='Piper Merriam',


### PR DESCRIPTION
### What was wrong?

Wrong value being set in `project.config` setter method.

### How was it fixed?

Changed to use appropriate value.

#### Cute Animal Picture

> put a cute animal picture here.

![b269674711ead8ef3862462ec45d1538](https://cloud.githubusercontent.com/assets/824194/23776060/20aae604-04e9-11e7-9398-c0a3f3f8c6f4.jpeg)
