### PR TITLE
fix compilation bug with abstract contracts

### DIFF
--- a/populus/utils/compile.py
+++ b/populus/utils/compile.py
@@ -89,7 +89,6 @@ def normalize_contract_data(contract_data):
         yield 'devdoc', _load_json_if_string(contract_data['devdoc'])
 
 
-@to_dict
 def normalize_contract_metadata(metadata):
     if not metadata:
         return None

--- a/tests/compilation/test_compiling_contract_sources.py
+++ b/tests/compilation/test_compiling_contract_sources.py
@@ -27,7 +27,7 @@ def test_compiling_project_contracts(project):
 @load_contract_fixture('ImportTestB.sol')
 @load_contract_fixture('ImportTestC.sol')
 def test_compiling_with_local_project_imports(project):
-    source_paths, contract_data = compile_project_contracts(project)
+    _, contract_data = compile_project_contracts(project)
 
     assert 'ImportTestA' in contract_data
     assert 'ImportTestB' in contract_data
@@ -39,3 +39,19 @@ def test_compiling_with_test_contracts(project):
     source_paths, contract_data = compile_project_contracts(project)
 
     assert 'TestMath' in contract_data
+
+
+@load_contract_fixture('Abstract.sol')
+def test_compiling_with_abstract_contract(project):
+    _, contract_data = compile_project_contracts(project)
+
+    assert 'Abstract' in contract_data
+
+
+@load_contract_fixture('Abstract.sol')
+@load_contract_fixture('UsesAbstract.sol')
+def test_compiling_with_abstract_contract_inhereted(project):
+    _, contract_data = compile_project_contracts(project)
+
+    assert 'Abstract' in contract_data
+    assert 'UsesAbstract' in contract_data

--- a/tests/fixtures/Abstract.sol
+++ b/tests/fixtures/Abstract.sol
@@ -1,0 +1,6 @@
+pragma solidity ^0.4.0;
+
+
+contract Abstract {
+  function doSomething() returns (bool);
+}

--- a/tests/fixtures/UsesAbstract.sol
+++ b/tests/fixtures/UsesAbstract.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.4.0;
+
+
+import {Abstract} from "./Abstract.sol";
+
+
+contract UsesAbstract is Abstract {
+  function doSomething() returns (bool) {
+    return true;
+  }
+}


### PR DESCRIPTION
### What was wrong?

Abstract contracts could not be compiled due to bug in how metadata was processed.

### How was it fixed?

Fixed `normalize_contract_metadata` function.

#### Cute Animal Picture

> put a cute animal picture here.

![2013-11-08-tumblr_miob1qupwt1qi28muo1_1280](https://cloud.githubusercontent.com/assets/824194/23779118/ad2fc63c-04fb-11e7-8aa1-f4c120e8a67c.jpeg)
