### PR TITLE
Account for cases where a node has been fast synced

### DIFF
--- a/populus/contracts/registrar.py
+++ b/populus/contracts/registrar.py
@@ -19,10 +19,8 @@ from .exceptions import (
 def address_sort_fn(web3, address):
     try:
         return find_deploy_block_number(web3, address)
-    except ValueError as err:
-        if 'Missing trie' in str(err):
-            return -1
-        raise
+    except ValueError:
+        return -1
 
 
 class Registrar(object):

--- a/populus/contracts/registrar.py
+++ b/populus/contracts/registrar.py
@@ -16,6 +16,15 @@ from .exceptions import (
 )
 
 
+def address_sort_fn(web3, address):
+    try:
+        return find_deploy_block_number(web3, address)
+    except ValueError as err:
+        if 'Missing trie' in str(err):
+            return -1
+        raise
+
+
 class Registrar(object):
     """
     Abstraction for recording known contracts on a given chain.
@@ -43,23 +52,31 @@ class Registrar(object):
         if not found_addresses:
             raise NoKnownAddress("No known address for contract")
 
-        addresses_with_code = tuple(
+        if len(found_addresses) == 1:
+            return found_addresses
+
+        addresses_with_code = tuple(set(
             address
             for address
             in found_addresses
             if self.chain.web3.eth.getCode(address) not in EMPTY_BYTECODE_VALUES
-        )
-        empty_addresses = tuple(
+        ))
+        empty_addresses = tuple(set(
             address
             for address
             in found_addresses
             if self.chain.web3.eth.getCode(address) in EMPTY_BYTECODE_VALUES
-        )
-        sorted_addresses = tuple(sorted(
-            set(addresses_with_code),
-            key=functools.partial(find_deploy_block_number, self.chain.web3),
-            reverse=True,
         ))
+
+        if len(addresses_with_code) > 1:
+            sorted_addresses = tuple(sorted(
+                addresses_with_code,
+                key=functools.partial(address_sort_fn, self.chain.web3),
+                reverse=True,
+            ))
+        else:
+            sorted_addresses = addresses_with_code
+
         known_addresses = tuple(itertools.chain(
             sorted_addresses,
             empty_addresses,

--- a/populus/utils/contracts.py
+++ b/populus/utils/contracts.py
@@ -226,6 +226,8 @@ def find_deploy_block_number(web3, address):
 
     while left + 1 < right:
         middle = (left + right) // 2
+        # This only works if the node was not fast synced for the provided
+        # `block_identifier`.
         middle_code = web3.eth.getCode(address, block_identifier=middle)
 
         if middle_code in EMPTY_BYTECODE_VALUES:

--- a/populus/utils/contracts.py
+++ b/populus/utils/contracts.py
@@ -228,7 +228,13 @@ def find_deploy_block_number(web3, address):
         middle = (left + right) // 2
         # This only works if the node was not fast synced for the provided
         # `block_identifier`.
-        middle_code = web3.eth.getCode(address, block_identifier=middle)
+        try:
+            middle_code = web3.eth.getCode(address, block_identifier=middle)
+        except ValueError as err:
+            if 'Missing trie node' in str(err):
+                left = middle
+                continue
+            raise
 
         if middle_code in EMPTY_BYTECODE_VALUES:
             left = middle
@@ -237,6 +243,11 @@ def find_deploy_block_number(web3, address):
 
     code_at_right = web3.eth.getCode(address, block_identifier=right)
     if code_at_right in EMPTY_BYTECODE_VALUES:
+        raise ValueError(
+            "Something went wrong with the binary search to find the deploy block"
+        )
+    code_at_previous_block = web3.eth.getCode(address, block_identifier=right - 1)
+    if code_at_previous_block not in EMPTY_BYTECODE_VALUES:
         raise ValueError(
             "Something went wrong with the binary search to find the deploy block"
         )


### PR DESCRIPTION
### What was wrong?

Part of the lookup process for contract addresses tries to order them by the date they were deployed.

### How was it fixed?

* Added some optimization to the body of `Registrar.get_contract_address` to allow it to return early and skip the sorting when the appropriate conditions arise.
* Adjusted `populus.utils.contracts.find_deploy_block_number`  to handle situations where some of the history is not available due to fast sync.
* Adjusted sorting logic within `Registrar.get_contract_address` to handle cases where we cannot find the deploy block due to fast sync'd database.

#### Cute Animal Picture

> put a cute animal picture here.

![d547d84e6421da4a7205bd5e489c3550](https://cloud.githubusercontent.com/assets/824194/24424253/3205369c-13bd-11e7-9f71-ee4f1977ff5f.jpeg)
