### PR TITLE
Allow empty passwords

### DIFF
--- a/populus/utils/cli.py
+++ b/populus/utils/cli.py
@@ -248,9 +248,11 @@ def request_account_unlock(chain, account, timeout):
     unlock_account_msg = (
         "Please provide the password to unlock account `{0}`.".format(account)
     )
+
+    # default="" is for allowing empty password
     unlock_successful = chain.web3.personal.unlockAccount(
         account,
-        click.prompt(unlock_account_msg, hide_input=True),
+        click.prompt(unlock_account_msg, hide_input=True, default=""),
         timeout,
     )
     if not unlock_successful:


### PR DESCRIPTION
### What was wrong?

Unlocking a (coinbase) account did not take an empty password as an input. Empty passwords are useful for test chains.

### How was it fixed?

Edited `click` call to allow an empty password.

#### Cute Animal Picture

```
                                                  (__)
          *        (__)                           (oo)
           \       (oo)                     /------\/
            \-------\/                     /|  |/  |
             | ==$ ||                     / |  [) ||
             ||----||                    *  ||----||
 
             ^^    ^^                       ^^    ^^
      Old "One Arm" belonged           This cow is obviously
        to Caesar's Palace             Hugh Hefner's Heifer
 
```
