### PR TITLE
Update tutorial.part-2.rst

### DIFF
--- a/docs/tutorial.part-2.rst
+++ b/docs/tutorial.part-2.rst
@@ -24,10 +24,11 @@ of your project named ``populus.json`` with the following contents
 .. code-block:: javascript
 
     {
+      "version": "3",
       "chains": {
         "horton": {
           "chain": {
-            "class": 'populus.chain.geth.LocalGethChain'
+            "class": "populus.chain.geth.LocalGethChain"
           },
           "web3": {
             "provider": {

--- a/docs/tutorial.part-2.rst
+++ b/docs/tutorial.part-2.rst
@@ -111,10 +111,11 @@ address should be.  Change your configuration to match this.
 .. code-block:: javascript
 
     {
+      "version": "3",
       "chains": {
         "horton": {
           "chain": {
-            "class": 'populus.chain.LocalGethChain'
+            "class": "populus.chain.LocalGethChain"
           },
           "web3": {
             "provider": {


### PR DESCRIPTION
### What was wrong?

Using `populus==2.0.0a4`, `populus.json` suggested in the docs didn't work.

```
json.decoder.JSONDecodeError: Expecting value: line 5 column 18 (char 66)
```

```
KeyError: 'version'
```

### How was it fixed?

Making the single quotes into double quotes, and adding a version keypair (but you can see that from the code!

#### Cute Animal Picture

![uqkurpf](https://cloud.githubusercontent.com/assets/513929/25315367/280516fe-2811-11e7-9d72-06345e7b27e6.gif)
