### PR TITLE
expand solc versions tested against on ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ env:
     - SOLC_VERSION=v0.4.8 TOX_POSARGS="-e py27-stdlib -e py27-gevent -e py34-stdlib -e py34-gevent -e py35-stdlib -e py35-gevent" GETH_VERSION=v1.6.6
     # Solc 0.4.11
     - SOLC_VERSION=v0.4.11 TOX_POSARGS="-e py27-stdlib -e py27-gevent -e py34-stdlib -e py34-gevent -e py35-stdlib -e py35-gevent" GETH_VERSION=v1.6.6
+    # Solc 0.4.12
+    - SOLC_VERSION=v0.4.12 TOX_POSARGS="-e py27-stdlib -e py27-gevent -e py34-stdlib -e py34-gevent -e py35-stdlib -e py35-gevent" GETH_VERSION=v1.6.6
+    # Solc 0.4.13
+    - SOLC_VERSION=v0.4.13 TOX_POSARGS="-e py27-stdlib -e py27-gevent -e py34-stdlib -e py34-gevent -e py35-stdlib -e py35-gevent" GETH_VERSION=v1.6.6
     # Linting
     - TOX_POSARGS="-e flake8"
   global:


### PR DESCRIPTION
### What was wrong?

Was not testing against the latest versions of solc

### How was it fixed?

Expanded CI test suite to include `0.4.12` and `0.4.13`.

#### Cute Animal Picture

![suard](https://user-images.githubusercontent.com/824194/28340249-46824b3e-6bcc-11e7-856c-159fd942dd07.jpg)
