### PR TITLE
Allow to pass Solidity command line options 

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -28,8 +28,8 @@ Currently the config file controls the following things.
 Compiler Configuration
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The following configuration options are available to control how populus
-compiles your project contracts.
+Each complication backend takes settings that are passed down to Solidity compiler
+Input Description (JSON) and command line.
 
 .. code-block:: javascript
 
@@ -39,13 +39,37 @@ compiles your project contracts.
         "backend": {
           "class": "populus.compilation.backends.SolcCombinedJSONBackend",
           "settings": {
-              "optimize": true,
-              "optimize_runs": 100,
-              "output_values": ["abi", "bin", "bin-runtime", "devdoc", "metadata", "userdoc"]
-          }
+              "stdin": {
+                "optimizer": {
+                  "enabled": true,
+                  "runs": 500
+                },
+                "outputSelection": {
+                  "*": {
+                    "*": [
+                      "abi",
+                      "metadata",
+                      "evm.bytecode",
+                      "evm.deployedBytecode"
+                    ]
+                  }
+                }
+              },
+              "command_line_options": {
+                "allow_paths": "/"
+              }
+            }
+          },
         }
       }
     }
+
+
+``backend.settings`` has two keys
+
+* ``stdin`` is `Solidity Input Description as JSON <http://solidity.readthedocs.io/en/develop/using-the-compiler.html?highlight=input%20description#input-description>`_
+
+* ``command_line_options`` are passed to Solidity compiler command line, as given keyword arguments to `py-solc` package's `solc.wrapper.solc_wrapper <https://github.com/pipermerriam/py-solc/blob/3a6de359dc31375df46418e6ffd7f45ab9567287/solc/wrapper.py#L20>_`
 
 Contract Source Directory
 """""""""""""""""""""""""
@@ -73,8 +97,8 @@ Settings for the compiler backend
 * default: ``{"optimize": true, "output_values": ["abi", "bin", "bin-runtime", "devdoc", "metadata", "userdoc"]}``
 
 
-Import Remappings
-"""""""""""""""""
+Configuring compiler for extra
+""""""""""""""""""""""""""""""
 
 Set `solc import path remappings <https://github.com/pipermerriam/py-solc#import-path-remappings>`_. This is especially useful if you want to use libraries like `OpenZeppelin <https://github.com/OpenZeppelin/zeppelin-solidity/>`_ with your project. Then you can directly import Zeppelin contracts like ``import "zeppelin/contracts/token/TransferableToken.sol";``.
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -31,6 +31,9 @@ Compiler Configuration
 Each complication backend takes settings that are passed down to Solidity compiler
 Input Description (JSON) and command line.
 
+Here is an example for the compilation backend settings when using
+multiple contracts folders besides Populus default ``contracts`` folder.
+
 .. code-block:: javascript
 
     {
@@ -56,10 +59,10 @@ Input Description (JSON) and command line.
                 }
               },
               "command_line_options": {
-                "allow_paths": "/"
+                "allow_paths": "/path-to-your-external-solidity-files"
               }
             }
-          },
+          }
         }
       }
     }

--- a/populus/assets/contract-data.v1.schema.json
+++ b/populus/assets/contract-data.v1.schema.json
@@ -45,6 +45,7 @@
       "type": "array",
       "items": {
         "anyOf": [
+          {"$ref": "#/definitions/FallbackABI"},
           {"$ref": "#/definitions/FunctionABI"},
           {"$ref": "#/definitions/EventABI"},
           {"$ref": "#/definitions/ConstructorABI"}
@@ -140,6 +141,15 @@
         "type": {
           "type": "string",
           "enum": ["function"]
+        }
+      }
+    },
+    "FallbackABI": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["fallback"]
         }
       }
     },

--- a/populus/compilation/backends/solc_standard_json.py
+++ b/populus/compilation/backends/solc_standard_json.py
@@ -115,11 +115,17 @@ class SolcStandardJSONBackend(BaseCompilerBackend):
             }
         }
 
-        std_input['settings'].update(self.compiler_settings.get("solidity_input_description", {}))
+        # solc command line options as passed to solc_wrapper()
+        # https://github.com/pipermerriam/py-solc/blob/3a6de359dc31375df46418e6ffd7f45ab9567287/solc/wrapper.py#L20
         command_line_options = self.compiler_settings.get("command_line_options", {})
 
-        self.logger.debug("std_input has: %s", std_input.keys())
-        self.logger.debug("JSON settings are: %s", std_input["settings"])
+        # Get Solidity Input Description settings section
+        # http://solidity.readthedocs.io/en/develop/using-the-compiler.html#input-description
+        std_input_settings = self.compiler_settings.get("solidity_input_description", {})
+        std_input['settings'].update(std_input_settings)
+
+        self.logger.debug("std_input sections: %s", std_input.keys())
+        self.logger.debug("Input Description JSON settings are: %s", std_input["settings"])
         self.logger.debug("Command line options are", command_line_options)
         try:
             compilation_result = compile_standard(std_input, **command_line_options)

--- a/populus/compilation/backends/solc_standard_json.py
+++ b/populus/compilation/backends/solc_standard_json.py
@@ -114,10 +114,15 @@ class SolcStandardJSONBackend(BaseCompilerBackend):
                 'remappings': import_remappings
             }
         }
-        std_input['settings'].update(self.compiler_settings)
 
+        std_input['settings'].update(self.compiler_settings.get("solidity_input_description", {}))
+        command_line_settings = self.compiler_settings.get("command_line_options", {})
+
+        print("Using keys", std_input.keys())
+        print("Settings are", std_input["settings"])
+        print("Command line settings are", command_line_settings)
         try:
-            compilation_result = compile_standard(std_input)
+            compilation_result = compile_standard(std_input, **command_line_settings)
         except ContractsNotFound:
             return {}
 

--- a/populus/compilation/backends/solc_standard_json.py
+++ b/populus/compilation/backends/solc_standard_json.py
@@ -116,13 +116,13 @@ class SolcStandardJSONBackend(BaseCompilerBackend):
         }
 
         std_input['settings'].update(self.compiler_settings.get("solidity_input_description", {}))
-        command_line_settings = self.compiler_settings.get("command_line_options", {})
+        command_line_options = self.compiler_settings.get("command_line_options", {})
 
-        print("Using keys", std_input.keys())
-        print("Settings are", std_input["settings"])
-        print("Command line settings are", command_line_settings)
+        self.logger.debug("std_input has: %s", std_input.keys())
+        self.logger.debug("JSON settings are: %s", std_input["settings"])
+        self.logger.debug("Command line options are", command_line_options)
         try:
-            compilation_result = compile_standard(std_input, **command_line_settings)
+            compilation_result = compile_standard(std_input, **command_line_options)
         except ContractsNotFound:
             return {}
 

--- a/populus/compilation/backends/solc_standard_json.py
+++ b/populus/compilation/backends/solc_standard_json.py
@@ -121,7 +121,7 @@ class SolcStandardJSONBackend(BaseCompilerBackend):
 
         # Get Solidity Input Description settings section
         # http://solidity.readthedocs.io/en/develop/using-the-compiler.html#input-description
-        std_input_settings = self.compiler_settings.get("solidity_input_description", {})
+        std_input_settings = self.compiler_settings.get("stdin", {})
         std_input['settings'].update(std_input_settings)
 
         self.logger.debug("std_input sections: %s", std_input.keys())

--- a/populus/compilation/backends/solc_standard_json.py
+++ b/populus/compilation/backends/solc_standard_json.py
@@ -126,7 +126,7 @@ class SolcStandardJSONBackend(BaseCompilerBackend):
 
         self.logger.debug("std_input sections: %s", std_input.keys())
         self.logger.debug("Input Description JSON settings are: %s", std_input["settings"])
-        self.logger.debug("Command line options are", command_line_options)
+        self.logger.debug("Command line options are: %s", command_line_options)
         try:
             compilation_result = compile_standard(std_input, **command_line_options)
         except ContractsNotFound:

--- a/populus/utils/module_loading.py
+++ b/populus/utils/module_loading.py
@@ -54,6 +54,6 @@ def split_at_longest_importable_path(dotted_path):
 
 def get_import_path(obj):
     return '.'.join((
-        obj.__name__,
         obj.__module__,
+        obj.__name__,
     ))


### PR DESCRIPTION
**Work in progress - do not merge - opened only for the discussion**

### What was wrong?

It was not possible to pass down `solc` command line options.

The required option is `--allow-paths` - otherwise using .sol library folders is not possible.

Furthermore added ABI definition for Fallback function.

### How was it fixed?

* Split compiler settings to two sections `stdin` that is Solidity Input Description JSON and `command_line_options` that is `solc_wrapper` keyword arguments

An example config section:

    "backends": {
      "SolcAutoBackend": {
        "class": "populus.compilation.backends.SolcAutoBackend",
        "settings": {
          "stdin": {
            "optimizer": {
              "enabled": true,
              "runs": 500
            },
            "outputSelection": {
              "*": {
                "*": [
                  "abi",
                  "metadata",
                  "evm.bytecode",
                  "evm.deployedBytecode"
                ]
              }
            }
          },
          "command_line_options": {
            "allow_paths": "/"
          }
        }
      },

#### Cute Animal Picture

```
 
                         (__)                        (__)
                 ^^      (oo)                        (--)
             ^^^^ /-------\/                        /-\/-\
          ^^^^^  / |     ||                        /|    |\
        ^^^^^   *  ||----||                       ^ |    | ^
     ^^^^^^^^  ====^^====^^====                     |    |
 ^^^^^^^^^^^^^/                                     /----\
 ^^^^^^^^^^^^^^^^^^                                /    \ \
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^               ^      * ^
      Cow Hanging Ten at Malibu           Cow sunning at Fort Lauderdale
                                              (What a bod, huh guys?)
```
