### PR TITLE
Depr warnings for solc combined, write config, config set delete

### DIFF
--- a/populus/cli/config_cmd.py
+++ b/populus/cli/config_cmd.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import logging
+import warnings
 
 import click
 
@@ -62,6 +63,8 @@ def config_set(ctx, key_value_pairs):
     """
     Sets the provided key/value pairs in the project config.
     """
+    warn_msg = 'Next release of populus will simplify configs. Config set will be dropped for simple config file edit'  # noqa: E501
+    warnings.warn(warn_msg, DeprecationWarning)
     logger = logging.getLogger('populus.cli.config.set')
     project = ctx.obj['PROJECT']
     for key, value in key_value_pairs:
@@ -104,6 +107,8 @@ def config_delete(ctx, keys):
     """
     Deletes the provided key/value pairs from the project config.
     """
+    warn_msg = "Next release of populus will simplify configs. Config delete will be dropped for simple config file edit"  # noqa: E501
+    warnings.warn(warn_msg, DeprecationWarning)
     logger = logging.getLogger('populus.cli.config.delete')
     project = ctx.obj['PROJECT']
     for key in keys:

--- a/populus/compilation/backends/solc_combined_json.py
+++ b/populus/compilation/backends/solc_combined_json.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import pprint
+import warnings
 
 from cytoolz.dicttoolz import (
     assoc,
@@ -135,6 +136,10 @@ class SolcCombinedJSONBackend(BaseCompilerBackend):
                 "versions <=0.4.8.  The SolcStandardJSONBackend should be used "
                 "for all versions >=0.4.9"
             )
+
+        warn_msg = 'Support for solc <0.4.11 will be dropped in the next populus release'
+        warnings.warn(warn_msg, DeprecationWarning)
+
         super(SolcCombinedJSONBackend, self).__init__(*args, **kwargs)
 
     def get_compiled_contracts(self, source_file_paths, import_remappings):

--- a/populus/project.py
+++ b/populus/project.py
@@ -52,6 +52,9 @@ class Project(object):
     _project_config_schema = None
 
     def write_config(self):
+
+        warn_msg = 'Next release of populus will simplify configs. Project write_config will be dropped for simple config file edit'  # noqa: E501
+        warnings.warn(warn_msg, DeprecationWarning)
         if self.config_file_path is None:
             config_file_path = get_default_project_config_file_path(self.project_dir)
         else:


### PR DESCRIPTION
### What was wrong?
Deprecation warnings for write config, config cli commands set, delete (confusing with user config), 
 and solc combined for solc < 4.11

### How was it fixed?
warnings


#### Cute Animal Picture

![06-wolves-cute](https://user-images.githubusercontent.com/3235489/30788031-20560d08-a19e-11e7-8448-890faccc3f4d.jpg)
.
