### PR TITLE
Aviah/project arg cli pytest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -20,12 +20,20 @@ from populus.utils.compile import (
 )
 from populus.utils.filesystem import (
     ensure_path_exists,
+    get_latest_mtime,
 )
 from populus.utils.testing import (
     get_tests_dir,
     link_bytecode_by_name,
 )
 
+from populus.utils.json import (
+    normalize_object_for_json,
+)
+
+from populus.utils.contracts import (
+    package_contracts,
+)
 
 POPULUS_SOURCE_ROOT = os.path.dirname(__file__)
 
@@ -50,6 +58,62 @@ def project_dir(tmpdir, monkeypatch):
     monkeypatch.syspath_prepend(_project_dir)
 
     return _project_dir
+
+
+CACHE_KEY_MTIME = "populus/project/compiled_contracts_mtime"
+CACHE_KEY_CONTRACTS = "populus/project/compiled_contracts"
+
+@pytest.fixture()
+def project(request, project_dir):
+    contracts = request.config.cache.get(CACHE_KEY_CONTRACTS, None)
+    mtime = request.config.cache.get(CACHE_KEY_MTIME, None)
+
+    project = Project(project_dir, create_config_file=True)
+
+    project.fill_contracts_cache(contracts, mtime)
+    request.config.cache.set(
+        CACHE_KEY_CONTRACTS,
+        normalize_object_for_json(project.compiled_contract_data),
+    )
+    request.config.cache.set(
+        CACHE_KEY_MTIME,
+        get_latest_mtime(project.get_all_source_file_paths()),
+    )
+
+    return project
+
+
+@pytest.yield_fixture()
+def chain(project):
+    with project.get_chain('tester') as chain:
+        yield chain
+
+
+@pytest.fixture()
+def registrar(chain):
+    return chain.registrar
+
+
+@pytest.fixture()
+def provider(chain):
+    return chain.provider
+
+
+@pytest.fixture()
+def web3(chain):
+    return chain.web3
+
+@pytest.fixture()
+def base_contract_factories(chain):
+    return package_contracts({
+        contract_name: chain.provider.get_base_contract_factory(contract_name)
+        for contract_name in chain.provider.get_all_contract_names()
+    })
+
+
+@pytest.fixture()
+def accounts(web3):
+    return web3.eth.accounts
 
 
 @pytest.fixture()
@@ -179,7 +243,7 @@ def _updated_project_config(project_dir, request):
     ))
 
     if key_value_pairs:
-        project = Project()
+        project = Project(project_dir, create_config_file=True)
 
         for key, value in key_value_pairs:
             if value is None:

--- a/docs/compiling.rst
+++ b/docs/compiling.rst
@@ -31,6 +31,16 @@ be done as follows.
     > Wrote compiled assets to: ./build/contracts.json
 
 
+Outside the project directory use
+
+
+.. code-block:: bash
+
+    $ populus -p /path/to/my/project/ compile
+
+
+
+
 Watching
 --------
 

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -46,7 +46,7 @@ project ``./contracts`` directory.
 	}
 
 
-We can deploy this contract to a local test chain like this.
+We can deploy this contract to a local test chain like this:
 
 .. code-block:: shell
 
@@ -72,6 +72,14 @@ We can deploy this contract to a local test chain like this.
 
 
 Above you can see the output for a basic deployment.
+
+If your are outside the project directory, use:
+
+.. code-block:: shell
+
+	$ populus -p /path/to/my/project deploy Wallet -c local_a
+
+
 
 Programmatically deploy a contract
 ----------------------------------

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -20,7 +20,7 @@ Command Line Options
       Populus
 
     Options:
-      -c, --config FILENAME  Specify a populus configuration file to be used.
+      -p, --project DIRECTORY  Specify a populus project directory to be used.
       -h, --help             Show this message and exit.
 
     Commands:
@@ -70,8 +70,15 @@ Initialize
       -h, --help  Show this message and exit.
 
 Running ``$ populus init`` will initialize the current directory with the
-default project layout that populus uses.
+default project layout that populus uses. If ``-p`` argument is provided, populus will init to that directory
 
 * ``./contracts/``
 * ``./contracts/Greeter.sol``
 * ``./tests/test_greeter.py``
+
+You can also init a project from another directory with:
+
+.. code-block:: shell
+
+    $ populus -p /path/to/my/project/ init
+

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,6 +1,8 @@
 Quickstart
 ==========
 
+Welcom to Populus! Populus has (almost) everything you need for Ethereum blockchain development.
+
 .. contents:: :local:
 
 
@@ -9,8 +11,8 @@ System Dependencies
 
 Populus depends on the following system dependencies.
 
-* `Solidity`_ : For contract compilation
-* `Go Ethereum`_: For running test chains and contract deployment.
+* The `Solidity`_ Compiler : Contracts are authored in the Solidity language, and then compiled to the bytecode of the Ethereum Virtual Machine (EVM).
+* `Geth`_: The official Go implementation of the Ethereum protocol. The Geth client runs a blockchain node, lets you interact with the blockchain, and also runs and deploys to the test blockchains during development.
 
 In addition, populus needs some system dependencies to be able to install the
 `PyEthereum`_ library.
@@ -39,14 +41,34 @@ OSX
     brew install pkg-config libffi autoconf automake libtool openssl
 
 
-Installation
-------------
+Install Populus
+---------------
 
 Populus can be installed using ``pip`` as follows.
 
 .. code-block:: shell
 
    $ pip install populus
+
+If you are installing on Ubuntu, and working with python3 (recommended):
+
+.. code-block:: shell
+
+    $ pip3 install populus
+
+
+.. note::
+
+    With Ubuntu, use Ubuntu's pip:
+
+    ``$sudo apt-get install python-pip``
+
+    or, for python 3:
+
+    ``$sudo apt-get install python3-pip``
+
+    You may need to install populus with sudo: ``$ sudo -H pip install populus``
+
 
 
 By default populus will use standard library tools for io operations like
@@ -67,7 +89,36 @@ following command.
    $ python setup.py install
 
 
-Initializing a new project
+Verify your installation
+
+.. code-block:: shell
+
+      $ populus
+
+      Usage: populus [OPTIONS] COMMAND [ARGS]...
+
+        Populus
+
+      Options:
+        -p, --project PATH  Specify a populus project directory
+        -l, --logging TEXT  Specify the logging level.  Allowed values are
+                            DEBUG/INFO or their numeric equivalents 10/20
+        -h, --help          Show this message and exit.
+
+      Commands:
+        chain    Manage and run ethereum blockchains.
+        compile  Compile project contracts, storing their...
+        config   Manage and run ethereum blockchains.
+        deploy   Deploys the specified contracts to a chain.
+        init     Generate project layout with an example...
+
+
+Great. Let's have the first populus project.
+
+
+
+
+Initializing a New Project
 --------------------------
 
 Populus can initialize your project using the ``$ populus init`` command.
@@ -86,12 +137,29 @@ Your project will now have a ``./contracts`` directory with a single Solidity
 source file in it named ``Greeter.sol``, as well as a ``./tests`` directory
 with a single test file named ``test_greeter.py``.
 
+Alternatively, you can init a new project by a directory:
+
+.. code-block:: shell
+
+    $ populus -p /path/to/my/project/ init
+
+
 Compiling your contracts
 ------------------------
 
 Before you compile our project, lets take a look at the ``Greeter`` contract
 that is generated as part of the project initialization.
 
+.. code-block:: shell
+
+    $ nano contracts/Greeter.sol
+
+.. note::
+
+    Check your IDE for Solidity extention/package.
+
+
+Here is the contract:
 
 .. code-block:: solidity
 
@@ -113,10 +181,13 @@ that is generated as part of the project initialization.
         }
     }
 
-``Greeter`` is simple contract that is initialized with a default greeting of
-the string ``'Hello'``.  It exposes the ``greet`` function which returns
-whatever string is set as the greeting, as well as a ``setGreeting`` function
-which allows the greeting to be changed.
+``Greeter`` is simple contract:
+
+* The ``contract`` keyword starts a contract definition
+* The contract has one public "state" variable, named ``greeting``.
+* The contract constrator function, ``function Greeter()``, which has the same name of the contract, initializes with a default greeting of the string ``'Hello'``.
+* The function ``greet`` is exposed, and returns whatever string is set as the greeting,
+* Also, the ``setGreeting`` function is available,  and allows the greeting to be changed.
 
 You can now compile the contract using ``$ populus compile``
 
@@ -135,6 +206,16 @@ You can now compile the contract using ``$ populus compile``
 
     > Wrote compiled assets to: ./build/contracts.json
 
+For compiling outside the project directory use:
+
+.. code-block:: shell
+
+    $ populus -p /path/to/my/project/ compile
+
+The build/contracts.json file contains a lot of information that the Solidity compiler produced.
+This is required to deploy and work with the contract. Some important info is the
+application binary interface (ABI) of the contract, which will allow to call it's functions after it's compiled,
+and the bytecode required to deploy the contract, and the bytecode that will run once the contract sits on the blockchain.
 
 Testing your contract
 ---------------------
@@ -163,7 +244,13 @@ following.
 
 
 You should see two tests, one that tests the default greeting, and one that
-tests that we can set a custom greeting.  You can run tests using the
+tests that we can set a custom greeting.
+
+Note that both test functions accept a ``chain`` argument. This "chain" is actually py.test fixture, provided by the populus pytest plugin.
+The chain in the tests is a populus "chain" object that runs a temporary blockchain called "tester". It quits after the test and saves nothing,
+so obviously not usable for long term runnig contracts, but great for testing.
+
+You can run tests using the
 ``py.test`` command line utility which was installed when you installed
 populus.
 
@@ -177,10 +264,56 @@ populus.
 
 You should see something akin to the output above with three passing tests.
 
+Finally, similarly to the tests deployment, test the same deployment from the command line:
+
+.. code-block:: bash
+
+    $ populus deploy --chain tester --no-wait-for-sync
+    > Found 1 contract source files
+    - contracts/Greeter.sol
+    > Compiled 1 contracts
+    - contracts/Greeter.sol:Greeter
+    Please select the desired contract:
+
+        0: Greeter
+
+Type 0 at the prompt, and enter.
+
+.. code-block:: bash
+
+
+    Beginning contract deployment.  Deploying 1 total contracts (1 Specified, 0 because of library dependencies).
+
+    Greeter
+    Deploying Greeter
+    Deploy Transaction Sent: 0x84d23fa8c38a09a3b29c4689364f71343058879639a617763ce675a336033bbe
+    Waiting for confirmation...
+
+    Transaction Mined
+    =================
+    Tx Hash      : 0x84d23fa8c38a09a3b29c4689364f71343058879639a617763ce675a336033bbe
+    Address      : 0xc305c901078781c232a2a521c2af7980f8385ee9
+    Gas Provided : 465729
+    Gas Used     : 365729
+
+
+    Verified contract bytecode @ 0xc305c901078781c232a2a521c2af7980f8385ee9
+    Deployment Successful.
+
+Nice. Of course, since this is an ad-hoc "tester" chain, it quits immediately, and nothing is really saved. But the deployment works and should
+work on a permanent blockchain, like the mainnet or testnet.
+
+Again, outside the project directory use:
+
+.. code-block:: shell
+
+    $ populus -p /path/to/my/project/ deploy --chain tester --no-wait-for-sync
+
+
 Setup for development and contribution
 --------------------------------------
 
-In order to configure the project locally and get the whole test suite passing, you'll 
+In order to configure the project locally and get the whole test suite passing, you'll
 need to make sure you're using the proper version of the ``solc`` compiler. Follow these
 steps to install all the dependencies:
 
@@ -213,7 +346,7 @@ except for ``solc``:
 Install Solidity
 ~~~~~~~~~~~~~~~~
 Here's where the fun begins: you'll have to build Solidity from source, and it
-specifically needs to be the ``release_0.4.8`` branch. Here's how to do that:
+specifically needs to be the ``release_0.4.13`` branch. Here's how to do that:
 
 First, clone the repository and switch to the proper branch:
 
@@ -221,7 +354,16 @@ First, clone the repository and switch to the proper branch:
 
     $ git clone --recursive https://github.com/ethereum/solidity.git
     $ cd solidity
-    $ git checkout release_0.4.8
+    $ git checkout release_0.4.13
+
+You can also download the tar or zip file at:
+
+    https://github.com/ethereum/solidity/releases
+
+.. note::
+
+    Use the tar.gz file to build from source, and make sure, after extracting the file, that the "deps" directory is not empty
+    and actually contains the dependencies.
 
 If you're on a Mac, you may need to accept the Xcode license as well. Make sure
 you have the latest version installed, and if you run into errors, try the following:
@@ -300,6 +442,6 @@ somewhere. Just retrace your steps and you'll figure it out.
 
 
 
-.. _Go Ethereum: https://github.com/ethereum/go-ethereum/
+.. _Geth: https://github.com/ethereum/go-ethereum/
 .. _Solidity: https://github.com/ethereum/solidity/
 .. _PyEthereum: https://github.com/ethereum/pyethereum/

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -185,9 +185,9 @@ Here is the contract:
 
 * The ``contract`` keyword starts a contract definition
 * The contract has one public "state" variable, named ``greeting``.
-* The contract constrator function, ``function Greeter()``, which has the same name of the contract, initializes with a default greeting of the string ``'Hello'``.
-* The function ``greet`` is exposed, and returns whatever string is set as the greeting,
-* Also, the ``setGreeting`` function is available,  and allows the greeting to be changed.
+* The contract constructor function, ``function Greeter()``, which has the same name of the contract, initializes with a default greeting of the string ``'Hello'``.
+* The ``greet`` function is exposed, and returns whatever string is set as the greeting,
+* The ``setGreeting`` function is available,  and allows the greeting to be changed.
 
 You can now compile the contract using ``$ populus compile``
 
@@ -246,9 +246,9 @@ following.
 You should see two tests, one that tests the default greeting, and one that
 tests that we can set a custom greeting.
 
-Note that both test functions accept a ``chain`` argument. This "chain" is actually py.test fixture, provided by the populus pytest plugin.
-The chain in the tests is a populus "chain" object that runs a temporary blockchain called "tester". It quits after the test and saves nothing,
-so obviously not usable for long term runnig contracts, but great for testing.
+Note that both test functions accept a ``chain`` argument. This "chain" is actually a `py.test fixture <https://docs.pytest.org/en/latest/fixture.html>`_ , provided by the populus pytest plugin.
+The chain in the tests is a populus "chain" object that runs a temporary blockchain called "tester". The tester chain is ephemeral. All blockchain state is reset at the beginning of each test run and is
+only stored in memory, so obviously not usable for long term runnig contracts, but great for testing.
 
 You can run tests using the
 ``py.test`` command line utility which was installed when you installed
@@ -345,8 +345,16 @@ except for ``solc``:
 
 Install Solidity
 ~~~~~~~~~~~~~~~~
-Here's where the fun begins: you'll have to build Solidity from source, and it
-specifically needs to be the ``release_0.4.13`` branch. Here's how to do that:
+You'll have to install solidity, recommended from release 4.11 or greater.
+
+Installtion scripts for binary:
+'''''''''''''''''''''''''''''''
+
+    https://github.com/pipermerriam/py-solc#installing-the-solc-binary
+
+
+Installtion scripts building it:
+''''''''''''''''''''''''''''''''
 
 First, clone the repository and switch to the proper branch:
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -47,7 +47,7 @@ Pytest Fixtures
 The test fixtures provided by populus are what make testing easy.  In order to
 use a fixture in your tests all you have to do add an argument with the same
 name to the signature of your test function.
- 
+
 
 
 Project
@@ -57,6 +57,7 @@ Project
 
 The :ref:`Project` object for your project.
 
+This project object is initialised first, and the rest of the fixtures are derived from it.
 
 .. code-block:: python
 
@@ -66,6 +67,37 @@ The :ref:`Project` object for your project.
 
         # raw compiled contract access
         assert 'MyContract' in project.compiled_contract_data
+
+
+How populus finds the project of the project fixture
+''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+If no other argument is provided, populus assumes that the tested project directory is the one where the tests run from.
+This is true if you run py.test from within the project's directory, or with a positional argument to this projecr's directory,
+e.g. ``$ py.test /path/to/my/project/``.
+
+If the tests are in a different directory, e.g. ``$ py.tests /path/to/tests/``,
+you will have to provide the tested project:
+
+1. With command line argument: ``$ py.test /path/to/tests/ --populus-project /path/to/my/project/``
+2. Or, in a pytest.ini file, with the following entry: ``populus_project=/path/to/my/project/``
+3. Or with an environment variable: ``PYTEST_POPULUS_PROJECT``. E.g., ``$ export PYTEST_POPULUS_PROJECT=/path/to/my/project/``
+
+If a project is provided in more than one place, then the first is the command line, then pytest.ini, then the environment variable.
+
+.. note:
+
+    Providing only the propulus project arg (via command line, or pytest.ini, or the environment variable) will not replace
+    py.test own tests finding. So you still need to provide pytest the correct tests directory, or rely on pytest tests
+    collecting.
+
+    So if you have a project at /home/username/projects/project_foo, then ``$ pytest --populus-project /home/username/projects/project_foo``
+    may not work if you run it say from /home/elsewhere. The argument will only tell pytest where to load the project fixture, but
+    not where the actual tests are.
+
+    The nice thing is that you can run the same tests suite on diffrent projects, each time apply the same test to another project,
+    where pytest will load the project fixture from another project.
+
 
 
 Chain

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -72,8 +72,8 @@ This project object is initialised first, and the rest of the fixtures are deriv
 How populus finds the project of the project fixture
 ''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-If no other argument is provided, populus assumes that the tested project directory is the one where the tests run from.
-This is true if you run py.test from within the project's directory, or with a positional argument to this projecr's directory,
+If no other argument is provided, populus defaults to using the current tests directory.
+This is true if you run py.test from within the project's directory, or with a positional argument to this project's directory,
 e.g. ``$ py.test /path/to/my/project/``.
 
 If the tests are in a different directory, e.g. ``$ py.tests /path/to/tests/``,
@@ -81,9 +81,15 @@ you will have to provide the tested project:
 
 1. With command line argument: ``$ py.test /path/to/tests/ --populus-project /path/to/my/project/``
 2. Or, in a pytest.ini file, with the following entry: ``populus_project=/path/to/my/project/``
-3. Or with an environment variable: ``PYTEST_POPULUS_PROJECT``. E.g., ``$ export PYTEST_POPULUS_PROJECT=/path/to/my/project/``
+3. Or with an environment variable: ``PYTEST_POPULUS_PROJECT``. E.g., ``PYTEST_POPULUS_PROJECT=/path/to/my/project/ py.test /path/to/tests/``
 
-If a project is provided in more than one place, then the first is the command line, then pytest.ini, then the environment variable.
+
+The precedence order for these different methods of setting the project directory is:
+
+#. command line
+#. pytest.ini
+#. environment variable
+
 
 .. note:
 

--- a/docs/tutorial.part-1.rst
+++ b/docs/tutorial.part-1.rst
@@ -108,3 +108,46 @@ installed when you installed populus.
     tests/test_greeter.py::test_named_greeting PASSED
 
 You should see something akin to the output above with three passing tests.
+
+Behind the scenes, populus uses a pytest plugin that creates a populus project object, and then provide this object,
+(and it's derived objects), to the test functions via a pytest fixture.
+
+Thus, tests run for a specific project.
+
+If you run py.test from within the project directory, populus will assume that the current working directory
+is the project you want to test, and the fixtures will be based on this directory.
+
+The same is true if you provide pytest one positional argument for testing, which is the project directory:
+
+.. code-block:: bash
+
+    $ py.test /path/to/my/project/
+
+Here, populus will provide the fixtures based on the project at ``/path/to/my/project/``. Pytest will also find the tests in that directory.
+Note that populus and py.test look for their files separatly. Pytest looks for and collects the tests, populus for the the populus.json and other project files.
+
+
+When you want to run tests that are saved outside the project directory, you will have to explictly provide the project directory.
+If the tests are at ``/path/to/tests/``, then you can set the tested *project* directory as follows:
+
+1. As a command line argument: ``$ py.test /path/to/tests/ --populus-project /path/to/my/project/``
+2. In a pytest.ini file, with the following entry: ``populus_project=/path/to/my/project/``
+3. With an environment variable: ``PYTEST_POPULUS_PROJECT``. E.g., ``$ export PYTEST_POPULUS_PROJECT=/path/to/my/project/``
+
+If you used method 2 or 3, that is with pytest.ini or an environment variable, then:
+
+.. code-block:: bash
+
+    $ py.test /path/to/tests/
+
+Will do, and populus will figure out the testing project from pytest.ini or the environment variable. The tests found at
+``/path/to/tests/`` will be applied to this project.
+
+.. note::
+
+    For pytest.ini files, make sure the file is in the right location, and that py.test actually picks it.
+    See https://docs.pytest.org/en/latest/customize.html#initialization-determining-rootdir-and-inifile .
+
+So by providing explicit project for testing, you can run tests from one project on another, or if all your projects
+provide a repeating functionality, you can use the same set of tests for all of them.
+

--- a/docs/tutorial.part-1.rst
+++ b/docs/tutorial.part-1.rst
@@ -124,10 +124,7 @@ The same is true if you provide pytest one positional argument for testing, whic
     $ py.test /path/to/my/project/
 
 Here, populus will provide the fixtures based on the project at ``/path/to/my/project/``. Pytest will also find the tests in that directory.
-Note that populus and py.test look for their files separatly. Pytest looks for and collects the tests, populus for the the populus.json and other project files.
 
-
-When you want to run tests that are saved outside the project directory, you will have to explictly provide the project directory.
 If the tests are at ``/path/to/tests/``, then you can set the tested *project* directory as follows:
 
 1. As a command line argument: ``$ py.test /path/to/tests/ --populus-project /path/to/my/project/``

--- a/populus/api/compile_contracts.py
+++ b/populus/api/compile_contracts.py
@@ -1,0 +1,26 @@
+from populus.compilation import (
+    compile_project_contracts,
+)
+
+from populus.utils.cli import (
+    watch_project_contracts,
+)
+from populus.utils.compat import (
+    spawn,
+)
+from populus.utils.compile import (
+    write_compiled_sources,
+)
+
+
+def compile_project(project, watch):
+
+    _, compiled_contracts = compile_project_contracts(project)
+    write_compiled_sources(project.compiled_contracts_asset_path, compiled_contracts)
+
+    if watch:
+        thread = spawn(
+            watch_project_contracts,
+            project=project,
+        )
+        thread.join()

--- a/populus/api/deploy.py
+++ b/populus/api/deploy.py
@@ -1,0 +1,147 @@
+from __future__ import absolute_import
+
+import logging
+
+import click
+
+from populus.utils.chains import (
+    is_synced,
+)
+from populus.utils.cli import (
+    select_chain,
+    deploy_contract_and_verify,
+    select_project_contract,
+)
+from populus.utils.compat import (
+    sleep,
+)
+from populus.utils.deploy import (
+    get_deploy_order,
+)
+
+
+def echo_post_deploy_message(web3, deployed_contracts):
+    logger = logging.getLogger('populus.cli.deploy.echo_post_deploy_message')
+
+    message = (
+        "========== Deploy Completed ==========\n"
+        "Deployed {n} contracts:"
+    ).format(
+        n=len(deployed_contracts),
+    )
+    logger.info(message)
+    for contract_name, deployed_contract in deployed_contracts:
+        deploy_receipt = web3.eth.getTransactionReceipt(deployed_contract.deploy_txn_hash)
+        gas_used = deploy_receipt['gasUsed']
+        deploy_txn = web3.eth.getTransaction(deploy_receipt['transactionHash'])
+        gas_provided = deploy_txn['gas']
+        logger.info("- {0} ({1}) gas: {2} / {3}".format(
+            contract_name,
+            deployed_contract.address,
+            gas_used,
+            gas_provided,
+        ))
+
+
+def deploy(project, logger, chain_name, wait_for_sync, contracts_to_deploy):
+    """
+    Deploys the specified contracts to a chain.
+    """
+
+    # Determine which chain should be used.
+    if not chain_name:
+        chain_name = select_chain(project)
+
+    compiled_contracts = project.compiled_contract_data
+
+    if contracts_to_deploy:
+        # validate that we *know* about all of the contracts
+        unknown_contracts = set(contracts_to_deploy).difference(
+            compiled_contracts.keys()
+        )
+        if unknown_contracts:
+            unknown_contracts_message = (
+                "Some contracts specified for deploy were not found in the "
+                "compiled project contracts.  These contracts could not be found "
+                "'{0}'.  Searched these known contracts '{1}'".format(
+                    ', '.join(sorted(unknown_contracts)),
+                    ', '.join(compiled_contracts.keys()),
+                )
+            )
+            raise click.ClickException(unknown_contracts_message)
+    else:
+        # prompt the user to select the desired contracts they want to deploy.
+        # Potentially display the currently deployed status.
+        contracts_to_deploy = [select_project_contract(project)]
+
+    with project.get_chain(chain_name) as chain:
+        provider = chain.provider
+        registrar = chain.registrar
+
+        # wait for the chain to start syncing.
+        if wait_for_sync:
+            logger.info("Waiting for chain to start syncing....")
+            while chain.wait.for_syncing() and is_synced(chain.web3):
+                sleep(1)
+            logger.info("Chain sync complete")
+
+        # Get the deploy order.
+        deploy_order = get_deploy_order(
+            contracts_to_deploy,
+            compiled_contracts,
+        )
+
+        # Display Start Message Info.
+        starting_msg = (
+            "Beginning contract deployment.  Deploying {0} total contracts ({1} "
+            "Specified, {2} because of library dependencies)."
+            "\n\n" +
+            (" > ".join(deploy_order))
+        ).format(
+            len(deploy_order),
+            len(contracts_to_deploy),
+            len(deploy_order) - len(contracts_to_deploy),
+        )
+        logger.info(starting_msg)
+
+        for contract_name in deploy_order:
+            if not provider.are_contract_dependencies_available(contract_name):
+                raise ValueError(
+                    "Something is wrong with the deploy order.  Some "
+                    "dependencies for {0} are not "
+                    "available.".format(contract_name)
+                )
+
+            # Check if we already have an existing deployed version of that
+            # contract (via the registry).  For each of these, prompt the user
+            # if they would like to use the existing version.
+            if provider.is_contract_available(contract_name):
+                # TODO: this block should be a standalone cli util.
+                # TODO: this block needs to use the `Provider` API
+                existing_contract_instance = provider.get_contract(contract_name)
+                found_existing_contract_prompt = (
+                    "Found existing version of {name} in registrar. "
+                    "Would you like to use the previously deployed "
+                    "contract @ {address}?".format(
+                        name=contract_name,
+                        address=existing_contract_instance.address,
+                    )
+                )
+                if click.prompt(found_existing_contract_prompt, default=True):
+                    continue
+
+            # We don't have an existing version of this contract available so
+            # deploy it.
+            contract_instance = deploy_contract_and_verify(
+                chain,
+                contract_name=contract_name,
+            )
+
+            # Store the contract address for linking of subsequent deployed contracts.
+            registrar.set_contract_address(contract_name, contract_instance.address)
+
+        # TODO: fix this message.
+        success_msg = (
+            "Deployment Successful."
+        )
+        logger.info(success_msg)

--- a/populus/api/project.py
+++ b/populus/api/project.py
@@ -33,7 +33,7 @@ def init_project(project_dir, logger):
             "Found existing `populus.json` file.  Not writing default config."
         )
 
-    project = Project(project_dir)
+    project = Project(project_dir, create_config_file=True)
     logger.info(
         "Wrote default populus configuration to `./{0}`.".format(
             os.path.relpath(project.config_file_path),

--- a/populus/api/project.py
+++ b/populus/api/project.py
@@ -1,0 +1,71 @@
+import os
+import shutil
+
+from populus import ASSETS_DIR
+
+from populus.config import (
+    load_default_config,
+    write_config,
+)
+
+from populus.utils.config import (
+    get_json_config_file_path,
+    check_if_json_config_file_exists,
+)
+from populus.utils.filesystem import (
+    ensure_path_exists,
+)
+
+GREETER_SOURCE_PATH = os.path.join(ASSETS_DIR, 'Greeter.sol')
+GREETER_TEST_PATH = os.path.join(ASSETS_DIR, 'test_greeter.py')
+
+
+def init_project(project, logger):
+
+    has_json_config = check_if_json_config_file_exists(project.project_dir)
+
+    if has_json_config:
+        logger.info(
+            "Found existing `populus.json` file.  Not writing default config."
+        )
+    else:
+        json_config_file_path = get_json_config_file_path(project.project_dir)
+        default_config = load_default_config()
+        write_config(
+            project.project_dir,
+            default_config,
+            json_config_file_path,
+        )
+        logger.info(
+            "Wrote default populus configuration to `./{0}`.".format(
+                os.path.relpath(json_config_file_path, project.project_dir),
+            )
+        )
+
+    project.load_config()
+
+    for source_dir in project.contracts_source_dirs:
+        if ensure_path_exists(source_dir):
+            logger.info(
+                "Created Directory: ./{0}".format(
+                    os.path.relpath(source_dir)
+                )
+            )
+
+    example_contract_path = os.path.join(project.contracts_source_dirs[0], 'Greeter.sol')
+    if not os.path.exists(example_contract_path):
+        shutil.copy(GREETER_SOURCE_PATH, example_contract_path)
+        logger.info("Created Example Contract: ./{0}".format(
+            os.path.relpath(example_contract_path)
+        ))
+
+    tests_dir = os.path.join(project.project_dir, 'tests')
+    if ensure_path_exists(tests_dir):
+        logger.info("Created Directory: ./{0}".format(os.path.relpath(tests_dir)))
+
+    example_tests_path = os.path.join(tests_dir, 'test_greeter.py')
+    if not os.path.exists(example_tests_path):
+        shutil.copy(GREETER_TEST_PATH, example_tests_path)
+        logger.info("Created Example Tests: ./{0}".format(
+            os.path.relpath(example_tests_path)
+        ))

--- a/populus/api/project.py
+++ b/populus/api/project.py
@@ -8,7 +8,7 @@ from populus.config import (
     write_config,
 )
 
-from populus.utils.config import (
+from populus.config.helpers import (
     get_json_config_file_path,
     check_if_json_config_file_exists,
 )

--- a/populus/api/project.py
+++ b/populus/api/project.py
@@ -3,46 +3,42 @@ import shutil
 
 from populus import ASSETS_DIR
 
-from populus.config import (
-    load_default_config,
-    write_config,
-)
-
 from populus.config.helpers import (
-    get_json_config_file_path,
     check_if_json_config_file_exists,
 )
+
 from populus.utils.filesystem import (
     ensure_path_exists,
+)
+
+from populus.project import (
+    Project,
 )
 
 GREETER_SOURCE_PATH = os.path.join(ASSETS_DIR, 'Greeter.sol')
 GREETER_TEST_PATH = os.path.join(ASSETS_DIR, 'test_greeter.py')
 
 
-def init_project(project, logger):
+def init_project(project_dir, logger):
 
-    has_json_config = check_if_json_config_file_exists(project.project_dir)
+    if project_dir is None:
+        project_dir = os.getcwd()
+    else:
+        project_dir = os.path.abspath(project_dir)
+
+    has_json_config = check_if_json_config_file_exists(project_dir)
 
     if has_json_config:
         logger.info(
             "Found existing `populus.json` file.  Not writing default config."
         )
-    else:
-        json_config_file_path = get_json_config_file_path(project.project_dir)
-        default_config = load_default_config()
-        write_config(
-            project.project_dir,
-            default_config,
-            json_config_file_path,
-        )
-        logger.info(
-            "Wrote default populus configuration to `./{0}`.".format(
-                os.path.relpath(json_config_file_path, project.project_dir),
-            )
-        )
 
-    project.load_config()
+    project = Project(project_dir)
+    logger.info(
+        "Wrote default populus configuration to `./{0}`.".format(
+            os.path.relpath(project.config_file_path),
+        )
+    )
 
     for source_dir in project.contracts_source_dirs:
         if ensure_path_exists(source_dir):
@@ -69,3 +65,5 @@ def init_project(project, logger):
         logger.info("Created Example Tests: ./{0}".format(
             os.path.relpath(example_tests_path)
         ))
+
+    return project

--- a/populus/chain/base.py
+++ b/populus/chain/base.py
@@ -20,7 +20,7 @@ from populus.wait import (
     Wait,
 )
 
-from populus.utils.config import (
+from populus.config.helpers import (
     sort_prioritized_configs,
 )
 from populus.utils.functional import (

--- a/populus/cli/compile_cmd.py
+++ b/populus/cli/compile_cmd.py
@@ -1,20 +1,10 @@
 import click
 
-from populus.compilation import (
-    compile_project_contracts,
-)
-
-from populus.utils.cli import (
-    watch_project_contracts,
-)
-from populus.utils.compat import (
-    spawn,
-)
-from populus.utils.compile import (
-    write_compiled_sources,
-)
-
 from .main import main
+
+from populus.api.compile_contracts import (
+    compile_project,
+)
 
 
 @main.command('compile')
@@ -36,13 +26,4 @@ def compile_cmd(ctx, watch):
     specify only named contracts in the specified file.
     """
     project = ctx.obj['PROJECT']
-
-    _, compiled_contracts = compile_project_contracts(project)
-    write_compiled_sources(project.compiled_contracts_asset_path, compiled_contracts)
-
-    if watch:
-        thread = spawn(
-            watch_project_contracts,
-            project=project,
-        )
-        thread.join()
+    compile_project(project, watch)

--- a/populus/cli/deploy_cmd.py
+++ b/populus/cli/deploy_cmd.py
@@ -4,45 +4,11 @@ import logging
 
 import click
 
-from populus.utils.chains import (
-    is_synced,
-)
-from populus.utils.cli import (
-    select_chain,
-    deploy_contract_and_verify,
-    select_project_contract,
-)
-from populus.utils.compat import (
-    sleep,
-)
-from populus.utils.deploy import (
-    get_deploy_order,
+from populus.api.deploy import (
+    deploy,
 )
 
 from .main import main
-
-
-def echo_post_deploy_message(web3, deployed_contracts):
-    logger = logging.getLogger('populus.cli.deploy.echo_post_deploy_message')
-
-    message = (
-        "========== Deploy Completed ==========\n"
-        "Deployed {n} contracts:"
-    ).format(
-        n=len(deployed_contracts),
-    )
-    logger.info(message)
-    for contract_name, deployed_contract in deployed_contracts:
-        deploy_receipt = web3.eth.getTransactionReceipt(deployed_contract.deploy_txn_hash)
-        gas_used = deploy_receipt['gasUsed']
-        deploy_txn = web3.eth.getTransaction(deploy_receipt['transactionHash'])
-        gas_provided = deploy_txn['gas']
-        logger.info("- {0} ({1}) gas: {2} / {3}".format(
-            contract_name,
-            deployed_contract.address,
-            gas_used,
-            gas_provided,
-        ))
 
 
 @main.command('deploy')
@@ -74,100 +40,4 @@ def deploy_cmd(ctx, chain_name, wait_for_sync, contracts_to_deploy):
     project = ctx.obj['PROJECT']
     logger = logging.getLogger('populus.cli.deploy')
 
-    # Determine which chain should be used.
-    if not chain_name:
-        chain_name = select_chain(project)
-
-    compiled_contracts = project.compiled_contract_data
-
-    if contracts_to_deploy:
-        # validate that we *know* about all of the contracts
-        unknown_contracts = set(contracts_to_deploy).difference(
-            compiled_contracts.keys()
-        )
-        if unknown_contracts:
-            unknown_contracts_message = (
-                "Some contracts specified for deploy were not found in the "
-                "compiled project contracts.  These contracts could not be found "
-                "'{0}'.  Searched these known contracts '{1}'".format(
-                    ', '.join(sorted(unknown_contracts)),
-                    ', '.join(compiled_contracts.keys()),
-                )
-            )
-            raise click.ClickException(unknown_contracts_message)
-    else:
-        # prompt the user to select the desired contracts they want to deploy.
-        # Potentially display the currently deployed status.
-        contracts_to_deploy = [select_project_contract(project)]
-
-    with project.get_chain(chain_name) as chain:
-        provider = chain.provider
-        registrar = chain.registrar
-
-        # wait for the chain to start syncing.
-        if wait_for_sync:
-            logger.info("Waiting for chain to start syncing....")
-            while chain.wait.for_syncing() and is_synced(chain.web3):
-                sleep(1)
-            logger.info("Chain sync complete")
-
-        # Get the deploy order.
-        deploy_order = get_deploy_order(
-            contracts_to_deploy,
-            compiled_contracts,
-        )
-
-        # Display Start Message Info.
-        starting_msg = (
-            "Beginning contract deployment.  Deploying {0} total contracts ({1} "
-            "Specified, {2} because of library dependencies)."
-            "\n\n" +
-            (" > ".join(deploy_order))
-        ).format(
-            len(deploy_order),
-            len(contracts_to_deploy),
-            len(deploy_order) - len(contracts_to_deploy),
-        )
-        logger.info(starting_msg)
-
-        for contract_name in deploy_order:
-            if not provider.are_contract_dependencies_available(contract_name):
-                raise ValueError(
-                    "Something is wrong with the deploy order.  Some "
-                    "dependencies for {0} are not "
-                    "available.".format(contract_name)
-                )
-
-            # Check if we already have an existing deployed version of that
-            # contract (via the registry).  For each of these, prompt the user
-            # if they would like to use the existing version.
-            if provider.is_contract_available(contract_name):
-                # TODO: this block should be a standalone cli util.
-                # TODO: this block needs to use the `Provider` API
-                existing_contract_instance = provider.get_contract(contract_name)
-                found_existing_contract_prompt = (
-                    "Found existing version of {name} in registrar. "
-                    "Would you like to use the previously deployed "
-                    "contract @ {address}?".format(
-                        name=contract_name,
-                        address=existing_contract_instance.address,
-                    )
-                )
-                if click.prompt(found_existing_contract_prompt, default=True):
-                    continue
-
-            # We don't have an existing version of this contract available so
-            # deploy it.
-            contract_instance = deploy_contract_and_verify(
-                chain,
-                contract_name=contract_name,
-            )
-
-            # Store the contract address for linking of subsequent deployed contracts.
-            registrar.set_contract_address(contract_name, contract_instance.address)
-
-        # TODO: fix this message.
-        success_msg = (
-            "Deployment Successful."
-        )
-        logger.info(success_msg)
+    deploy(project, logger, chain_name, wait_for_sync, contracts_to_deploy)

--- a/populus/cli/init_cmd.py
+++ b/populus/cli/init_cmd.py
@@ -1,29 +1,10 @@
 import logging
-import os
-import shutil
-
 import click
-
-from populus import ASSETS_DIR
-
-from populus.config import (
-    load_default_config,
-    write_config,
-)
-
-from populus.utils.config import (
-    get_json_config_file_path,
-    check_if_json_config_file_exists,
-)
-from populus.utils.filesystem import (
-    ensure_path_exists,
-)
-
 from .main import main
 
-
-GREETER_SOURCE_PATH = os.path.join(ASSETS_DIR, 'Greeter.sol')
-GREETER_TEST_PATH = os.path.join(ASSETS_DIR, 'test_greeter.py')
+from populus.api.project import (
+    init_project,
+)
 
 
 @main.command('init')
@@ -35,50 +16,4 @@ def init_cmd(ctx):
     logger = logging.getLogger('populus.cli.init_cmd')
     project = ctx.obj['PROJECT']
 
-    has_json_config = check_if_json_config_file_exists(project.project_dir)
-
-    if has_json_config:
-        logger.info(
-            "Found existing `populus.json` file.  Not writing default config."
-        )
-    else:
-        json_config_file_path = get_json_config_file_path(project.project_dir)
-        default_config = load_default_config()
-        write_config(
-            project.project_dir,
-            default_config,
-            json_config_file_path,
-        )
-        logger.info(
-            "Wrote default populus configuration to `./{0}`.".format(
-                os.path.relpath(json_config_file_path, project.project_dir),
-            )
-        )
-
-    project.load_config()
-
-    for source_dir in project.contracts_source_dirs:
-        if ensure_path_exists(source_dir):
-            logger.info(
-                "Created Directory: ./{0}".format(
-                    os.path.relpath(source_dir)
-                )
-            )
-
-    example_contract_path = os.path.join(project.contracts_source_dirs[0], 'Greeter.sol')
-    if not os.path.exists(example_contract_path):
-        shutil.copy(GREETER_SOURCE_PATH, example_contract_path)
-        logger.info("Created Example Contract: ./{0}".format(
-            os.path.relpath(example_contract_path)
-        ))
-
-    tests_dir = os.path.join(project.project_dir, 'tests')
-    if ensure_path_exists(tests_dir):
-        logger.info("Created Directory: ./{0}".format(os.path.relpath(tests_dir)))
-
-    example_tests_path = os.path.join(tests_dir, 'test_greeter.py')
-    if not os.path.exists(example_tests_path):
-        shutil.copy(GREETER_TEST_PATH, example_tests_path)
-        logger.info("Created Example Tests: ./{0}".format(
-            os.path.relpath(example_tests_path)
-        ))
+    init_project(project, logger)

--- a/populus/cli/init_cmd.py
+++ b/populus/cli/init_cmd.py
@@ -14,6 +14,6 @@ def init_cmd(ctx):
     Generate project layout with an example contract.
     """
     logger = logging.getLogger('populus.cli.init_cmd')
-    project = ctx.obj['PROJECT']
+    project_dir = ctx.obj['PROJECT_DIR']
 
-    init_project(project, logger)
+    init_project(project_dir, logger)

--- a/populus/cli/main.py
+++ b/populus/cli/main.py
@@ -40,14 +40,13 @@ def validate_logging_level(ctx, param, value):
 
 @click.group(context_settings=CONTEXT_SETTINGS)
 @click.option(
-    '--config',
-    '-c',
-    'config_file_path',
+    '--project',
+    '-p',
+    'project_dir',
     help=(
-        "Specify a populus configuration file to be used.  No other "
-        "configuration files will be loaded"
+        "Specify a populus project directory"
     ),
-    type=click.Path(exists=True, dir_okay=False),
+    type=click.Path(exists=True, dir_okay=True),
 )
 @click.option(
     '--logging',
@@ -61,40 +60,43 @@ def validate_logging_level(ctx, param, value):
     callback=validate_logging_level,
 )
 @click.pass_context
-def main(ctx, config_file_path, logging_level):
+def main(ctx, project_dir, logging_level):
     """
     Populus
     """
     logger = get_logger_with_click_handler('populus', level=logging_level)
-
-    project = Project(config_file_path)
-
-    config_version = project.config['version']
-    subcommand_bypasses_config_version = ctx.invoked_subcommand in {'config', 'init'}
-
-    if not subcommand_bypasses_config_version and config_version != LATEST_VERSION:
-        old_config_version_msg = (
-            "================ warning =================\n"
-            "Your populus config file is current at version {0}. "
-            "The latest version is {1}.  You can use the `populus config "
-            "upgrade` command to upgrade your config file to the latest version\n"
-            "================ warning =================\n\n".format(
-                config_version,
-                LATEST_VERSION,
-            )
-        )
-        warnings.warn(DeprecationWarning(old_config_version_msg))
-        logger.warning(old_config_version_msg)
-        proceed_msg = (
-            "Without and up-to-date configuration file Populus may not function "
-            "correctly.  Would you still like to proceed?"
-        )
-        if not click.confirm(proceed_msg):
-            ctx.exit(1)
-
-    if not any(is_same_path(p, project.project_dir) for p in sys.path):
-        # ensure that the project directory is in the sys.path
-        sys.path.insert(0, project.project_dir)
-
     ctx.obj = {}
-    ctx.obj['PROJECT'] = project
+    ctx.obj['PROJECT_DIR'] = project_dir
+
+    if ctx.invoked_subcommand != 'init':
+
+        project = Project(project_dir)
+
+        config_version = project.config['version']
+        subcommand_bypasses_config_version = ctx.invoked_subcommand in {'config'}
+
+        if not subcommand_bypasses_config_version and config_version != LATEST_VERSION:
+            old_config_version_msg = (
+                "================ warning =================\n"
+                "Your populus config file is current at version {0}. "
+                "The latest version is {1}.  You can use the `populus config "
+                "upgrade` command to upgrade your config file to the latest version\n"
+                "================ warning =================\n\n".format(
+                    config_version,
+                    LATEST_VERSION,
+                )
+            )
+            warnings.warn(DeprecationWarning(old_config_version_msg))
+            logger.warning(old_config_version_msg)
+            proceed_msg = (
+                "Without and up-to-date configuration file Populus may not function "
+                "correctly.  Would you still like to proceed?"
+            )
+            if not click.confirm(proceed_msg):
+                ctx.exit(1)
+
+        if not any(is_same_path(p, project.project_dir) for p in sys.path):
+            # ensure that the project directory is in the sys.path
+            sys.path.insert(0, project.project_dir)
+
+        ctx.obj['PROJECT'] = project

--- a/populus/config/__init__.py
+++ b/populus/config/__init__.py
@@ -15,7 +15,6 @@ from .loading import (  # noqa: F401
     write_config,
 )
 from .defaults import (  # noqa: F401
-    get_default_config_path,
     load_default_config,
 )
 from .validation import (  # noqa: F401

--- a/populus/config/backend.py
+++ b/populus/config/backend.py
@@ -6,7 +6,7 @@ from populus.utils.module_loading import (
 from populus.utils.types import (
     is_string,
 )
-from populus.utils.config import (
+from populus.config.helpers import (
     ClassImportPath,
 )
 

--- a/populus/config/base.py
+++ b/populus/config/base.py
@@ -16,7 +16,7 @@ from populus.utils.mappings import (
     pop_nested_key,
     flatten_mapping,
 )
-from populus.utils.config import (
+from populus.config.helpers import (
     get_empty_config,
     resolve_config,
 )

--- a/populus/config/chain.py
+++ b/populus/config/chain.py
@@ -4,7 +4,7 @@ from populus.utils.module_loading import (
 from populus.utils.types import (
     is_string,
 )
-from populus.utils.config import (
+from populus.config.helpers import (
     ClassImportPath,
 )
 

--- a/populus/config/compiler.py
+++ b/populus/config/compiler.py
@@ -7,7 +7,7 @@ from eth_utils import (
 from populus.utils.module_loading import (
     import_string,
 )
-from populus.utils.config import (
+from populus.config.helpers import (
     ClassImportPath,
 )
 

--- a/populus/config/helpers.py
+++ b/populus/config/helpers.py
@@ -22,23 +22,16 @@ from populus.utils.module_loading import (
 JSON_CONFIG_FILENAME = './populus.json'
 
 
-def get_json_config_file_path(project_dir=None):
-    if project_dir is None:
-        project_dir = os.getcwd()
+def get_json_config_file_path(project_dir):
 
     json_config_file_path = os.path.join(project_dir, JSON_CONFIG_FILENAME)
     return json_config_file_path
 
 
-def check_if_json_config_file_exists(project_dir=None):
-    if project_dir is None:
-        project_dir = os.getcwd()
+def check_if_json_config_file_exists(project_dir):
 
     json_config_file_path = get_json_config_file_path(project_dir)
     return os.path.exists(json_config_file_path)
-
-
-get_default_project_config_file_path = get_json_config_file_path
 
 
 def get_empty_config():

--- a/populus/config/helpers.py
+++ b/populus/config/helpers.py
@@ -10,11 +10,11 @@ from eth_utils import (
     to_ordered_dict,
 )
 
-from .mappings import (
+from populus.utils.mappings import (
     get_nested_key,
     has_nested_key,
 )
-from .module_loading import (
+from populus.utils.module_loading import (
     import_string,
 )
 

--- a/populus/config/web3.py
+++ b/populus/config/web3.py
@@ -9,7 +9,7 @@ from web3 import Web3
 from populus.utils.module_loading import (
     import_string,
 )
-from populus.utils.config import (
+from populus.config.helpers import (
     ClassImportPath,
 )
 

--- a/populus/plugin.py
+++ b/populus/plugin.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from populus.project import Project
@@ -12,17 +13,56 @@ from populus.utils.json import (
     normalize_object_for_json,
 )
 
+from populus.config.helpers import (
+    get_json_config_file_path,
+)
+
+
+def pytest_addoption(parser):
+
+    parser.addoption("--populus-project", help="populus project root directory")
+    parser.addini("populus_project", "populus project root directory")
+
+
+def get_populus_option(cmdline_option, ini_option, environ_var, pytestconfig, default=None):
+
+    if pytestconfig.getoption(cmdline_option, default=False):
+            return pytestconfig.getoption(cmdline_option)
+    else:
+        if pytestconfig.getini(ini_option):
+            return pytestconfig.getini(ini_option)
+        elif environ_var in os.environ.keys():
+            return os.environ[environ_var]
+
+    return default
+
 
 CACHE_KEY_MTIME = "populus/project/compiled_contracts_mtime"
 CACHE_KEY_CONTRACTS = "populus/project/compiled_contracts"
 
 
 @pytest.fixture()
-def project(request):
+def project(request, pytestconfig):
+
+    project_dir = get_populus_option(
+        cmdline_option="--populus-project",
+        ini_option="populus_project",
+        environ_var="PYTEST_POPULUS_PROJECT",
+        pytestconfig=pytestconfig,
+        default=pytestconfig.args[0]
+    )
+
+    if not os.path.exists(get_json_config_file_path(project_dir)):
+        raise FileNotFoundError(
+            "No populus project found for testing in {project_dir}".format(
+                project_dir=project_dir
+            )
+        )
+
     contracts = request.config.cache.get(CACHE_KEY_CONTRACTS, None)
     mtime = request.config.cache.get(CACHE_KEY_MTIME, None)
 
-    project = Project()
+    project = Project(project_dir, create_config_file=True)
 
     project.fill_contracts_cache(contracts, mtime)
     request.config.cache.set(

--- a/populus/project.py
+++ b/populus/project.py
@@ -28,7 +28,7 @@ from populus.utils.filesystem import (
     relpath,
     get_latest_mtime,
 )
-from populus.utils.config import (
+from populus.config.helpers import (
     check_if_json_config_file_exists,
     get_default_project_config_file_path,
     get_json_config_file_path,

--- a/populus/project.py
+++ b/populus/project.py
@@ -54,7 +54,7 @@ class Project(object):
     project_dir = None
     config_file_path = None
 
-    def __init__(self, project_dir=None):
+    def __init__(self, project_dir=None, create_config_file=False):
 
         if project_dir is None:
             self.project_dir = os.getcwd()
@@ -63,8 +63,15 @@ class Project(object):
 
         self.config_file_path = get_json_config_file_path(self.project_dir)
         if not os.path.exists(self.config_file_path):
-            defaults_path = get_default_config_path()
-            shutil.copyfile(defaults_path, self.config_file_path)
+            if create_config_file:
+                defaults_path = get_default_config_path()
+                shutil.copyfile(defaults_path, self.config_file_path)
+            else:
+                raise FileNotFoundError(
+                    "No project config file found at {project_dir}".format(
+                        project_dir=self.project_dir
+                    )
+                )
 
         self.load_config()
 

--- a/populus/project.py
+++ b/populus/project.py
@@ -1,22 +1,33 @@
 import os
+import shutil
 import itertools
 import warnings
+
+from eth_utils import (
+    to_tuple,
+)
 
 from populus.compilation import (
     compile_project_contracts,
 )
+
 from populus.config import (
     ChainConfig,
     CompilerConfig,
     Config,
-    get_default_config_path,
     load_config as _load_config,
     load_config_schema,
     write_config as _write_config,
 )
+
+from populus.config.defaults import (
+    get_default_config_path,
+)
+
 from populus.utils.chains import (
     get_base_blockchain_storage_dir,
 )
+
 from populus.utils.compile import (
     get_build_asset_dir,
     get_compiled_contracts_asset_path,
@@ -24,29 +35,42 @@ from populus.utils.compile import (
     get_project_source_paths,
     get_test_source_paths,
 )
+
 from populus.utils.filesystem import (
-    relpath,
     get_latest_mtime,
 )
+
 from populus.config.helpers import (
-    check_if_json_config_file_exists,
-    get_default_project_config_file_path,
     get_json_config_file_path,
 )
+
 from populus.utils.testing import (
     get_tests_dir,
 )
 
 
 class Project(object):
-    def __init__(self, config_file_path=None):
-        self.config_file_path = config_file_path
+
+    project_dir = None
+    config_file_path = None
+
+    def __init__(self, project_dir=None):
+
+        if project_dir is None:
+            self.project_dir = os.getcwd()
+        else:
+            self.project_dir = os.path.abspath(project_dir)
+
+        self.config_file_path = get_json_config_file_path(self.project_dir)
+        if not os.path.exists(self.config_file_path):
+            defaults_path = get_default_config_path()
+            shutil.copyfile(defaults_path, self.config_file_path)
+
         self.load_config()
 
     #
     # Config
     #
-    config_file_path = None
 
     _project_config = None
     _project_config_schema = None
@@ -55,33 +79,17 @@ class Project(object):
 
         warn_msg = 'Next release of populus will simplify configs. Project write_config will be dropped for simple config file edit'  # noqa: E501
         warnings.warn(warn_msg, DeprecationWarning)
-        if self.config_file_path is None:
-            config_file_path = get_default_project_config_file_path(self.project_dir)
-        else:
-            config_file_path = self.config_file_path
-
-        self.config_file_path = _write_config(
+        _write_config(
             self.project_dir,
             self.config,
-            write_path=config_file_path,
+            write_path=self.config_file_path,
         )
 
         return self.config_file_path
 
     def load_config(self):
         self._config_cache = None
-
-        if self.config_file_path is None:
-            has_json_config = check_if_json_config_file_exists()
-
-            if has_json_config:
-                path_to_load = get_json_config_file_path()
-            else:
-                path_to_load = get_default_config_path()
-        else:
-            path_to_load = self.config_file_path
-
-        self._project_config = _load_config(path_to_load)
+        self._project_config = _load_config(self.config_file_path)
 
         config_version = self._project_config['version']
         self._project_config_schema = load_config_schema(config_version)
@@ -117,12 +125,6 @@ class Project(object):
     # Project
     #
     @property
-    @relpath
-    def project_dir(self):
-        return self.config.get('populus.project_dir', os.getcwd())
-
-    @property
-    @relpath
     def tests_dir(self):
         return get_tests_dir(self.project_dir)
 
@@ -130,12 +132,10 @@ class Project(object):
     # Contracts
     #
     @property
-    @relpath
     def compiled_contracts_asset_path(self):
         return get_compiled_contracts_asset_path(self.build_asset_dir)
 
     @property
-    @relpath
     def contracts_source_dir(self):
         warnings.warn(DeprecationWarning(
             "project.contracts_source_dir has been replaced by the plural, "
@@ -149,15 +149,15 @@ class Project(object):
         )[0]
 
     @property
-    @relpath
+    @to_tuple
     def contracts_source_dirs(self):
-        return self.config.get(
-            'compilation.contracts_source_dirs',
-            get_contracts_source_dirs(self.project_dir),
-        )
+        source_dirs = self.config.get('compilation.contracts_source_dirs')
+        if source_dirs:
+            return [os.path.join(self.project_dir, contracts_dir) for contracts_dir in source_dirs]
+        else:
+            return get_contracts_source_dirs(self.project_dir)
 
     @property
-    @relpath
     def build_asset_dir(self):
         return get_build_asset_dir(self.project_dir)
 
@@ -243,6 +243,5 @@ class Project(object):
         return chain
 
     @property
-    @relpath
     def base_blockchain_storage_dir(self):
         return get_base_blockchain_storage_dir(self.project_dir)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts= -v --durations 10 --showlocals
+addopts= -v --durations 10 --showlocals -p no:ethereum
 python_paths= .

--- a/tests/cli/test_request_account_unlock_helper_fn.py
+++ b/tests/cli/test_request_account_unlock_helper_fn.py
@@ -19,7 +19,7 @@ from populus.project import Project
 
 @pytest.mark.skip(reason="Unlocked account checker is broken")
 def test_request_account_unlock_with_correct_password(project_dir):
-    project = Project()
+    project = Project(project_dir, create_config_file=True)
     chain = project.get_chain('temp')
 
     # create 3 new accounts
@@ -43,7 +43,7 @@ def test_request_account_unlock_with_correct_password(project_dir):
 
 @pytest.mark.skip(reason="Unlocked account checker is broken")
 def test_request_account_unlock_with_bad_password(project_dir):
-    project = Project()
+    project = Project(project_dir, create_config_file=True)
     chain = project.get_chain('temp')
 
     # create 3 new accounts

--- a/tests/cli/test_select_chain_utility_fn.py
+++ b/tests/cli/test_select_chain_utility_fn.py
@@ -35,7 +35,7 @@ from populus.utils.cli import (
     ),
 )
 def test_cli_select_chain_helper(project_dir, write_project_file, stdin, expected):
-    project = Project()
+    project = Project(project_dir, create_config_file=True)
     project.config['chains.local_a.chain.class'] = 'populus.chain.TesterChain'
     project.config['chains.local_a.web3.provider.class'] = 'web3.providers.ipc.IPCProvider'
     project.config['chains.local_a.web3.provider.settings.ipc_path'] = (
@@ -69,7 +69,7 @@ def test_cli_select_chain_helper(project_dir, write_project_file, stdin, expecte
     'stdin', ('local_a\n', '20\n'),
 )
 def test_cli_select_chain_helper_select_invalid_options(project_dir, stdin):
-    project = Project()
+    project = Project(project_dir, create_config_file=True)
 
     assert 'local_a' not in project.config['chains']
     assert len(project.config['chains']) < 20

--- a/tests/cli/test_select_project_contract_helper_fn.py
+++ b/tests/cli/test_select_project_contract_helper_fn.py
@@ -27,7 +27,7 @@ def test_select_project_contract_helper_a(project_dir,
     write_project_file('contracts/ContractB.sol', 'contract B { function B() {}}')
     write_project_file('contracts/ContractC.sol', 'contract C { function C() {}}')
 
-    project = Project()
+    project = Project(project_dir, create_config_file=True)
 
     assert 'A' in project.compiled_contract_data
     assert 'B' in project.compiled_contract_data
@@ -60,7 +60,7 @@ def test_select_project_contract_helper_b(project_dir,
     write_project_file('contracts/ContractB.sol', 'contract B { function B() {}}')
     write_project_file('contracts/ContractC.sol', 'contract C { function C() {}}')
 
-    project = Project()
+    project = Project(project_dir, create_config_file=True)
 
     assert 'A' in project.compiled_contract_data
     assert 'B' in project.compiled_contract_data

--- a/tests/compile-utils/test_find_solidity_source_files.py
+++ b/tests/compile-utils/test_find_solidity_source_files.py
@@ -11,7 +11,7 @@ from populus.utils.filesystem import (
 
 
 def test_gets_correct_files_default_dir(project_dir, write_project_file):
-    project = Project()
+    project = Project(project_dir, create_config_file=True)
     file_names = tuple(itertools.chain.from_iterable(
         find_solidity_source_files(source_dir)
         for source_dir

--- a/tests/config-utils/test_class_import_path_descriptor.py
+++ b/tests/config-utils/test_class_import_path_descriptor.py
@@ -2,7 +2,7 @@ import pytest
 
 import numbers
 
-from populus.utils.config import (
+from populus.config.helpers import (
     ClassImportPath,
 )
 

--- a/tests/config-utils/test_resolve_config.py
+++ b/tests/config-utils/test_resolve_config.py
@@ -3,7 +3,7 @@ import pytest
 from populus.config import (
     Config,
 )
-from populus.utils.config import (
+from populus.config.helpers import (
     resolve_config,
 )
 

--- a/tests/configuration/test_default_config_is_valid.py
+++ b/tests/configuration/test_default_config_is_valid.py
@@ -2,6 +2,6 @@ from populus import Project
 
 
 def test_default_configuration_is_valid(project_dir):
-    project = Project()
+    project = Project(project_dir, create_config_file=True)
     assert project._project_config_schema is not None
     project.config.validate()

--- a/tests/project/test_get_chain.py
+++ b/tests/project/test_get_chain.py
@@ -7,7 +7,7 @@ from populus.project import (
 
 @pytest.mark.slow
 def test_project_tester_chain(project_dir):
-    project = Project()
+    project = Project(project_dir, create_config_file=True)
 
     chain = project.get_chain('tester')
 
@@ -18,7 +18,7 @@ def test_project_tester_chain(project_dir):
 
 @pytest.mark.slow
 def test_project_testrpc_chain(project_dir):
-    project = Project()
+    project = Project(project_dir, create_config_file=True)
 
     chain = project.get_chain('testrpc')
 

--- a/tests/project/test_project_directory_properties.py
+++ b/tests/project/test_project_directory_properties.py
@@ -17,7 +17,7 @@ from populus.utils.filesystem import (
 
 
 def test_project_directory_properties(project_dir):
-    project = Project()
+    project = Project(project_dir, create_config_file=True)
 
     if sys.version_info.major != 2:
         with pytest.warns(DeprecationWarning):

--- a/tests/project/test_project_object_defaults_to_cwd.py
+++ b/tests/project/test_project_object_defaults_to_cwd.py
@@ -3,6 +3,6 @@ from populus.project import Project
 
 
 def test_project_dir_defaults_to_cwd(project_dir):
-    project = Project()
+    project = Project(project_dir, create_config_file=True)
 
     assert is_same_path(project.project_dir, project_dir)


### PR DESCRIPTION
### What was wrong?

The populus command runs for the cwd

### How was it fixed?

add -p argument which can run on the provided project directory
pytest also has a --populus-project argument (or via pytest.ini, or environ var) which points to a project to run the test on.

E.g.

$ populus -p myproject/project_foo init
$ populus -p myproject/project_foo compile
$ pytest myproject/project_foo

Or giving a tests directory to apply to another project:
$ pytest tests_dir --populus-project project_dir

The "project" fixture will come from project_dir, the tests from tests_dir

#### Cute Animal Picture

> put a cute animal picture here.


![squirrel](https://user-images.githubusercontent.com/3235489/30888772-fb05e2f6-a32a-11e7-877a-a5e188123166.jpeg)
