### PR TITLE
account for the internal api change with web3

### DIFF
--- a/populus/utils/wait.py
+++ b/populus/utils/wait.py
@@ -37,8 +37,13 @@ def wait_for_transaction_receipt(web3, txn_hash, timeout=120, poll_interval=None
 
 def wait_for_block_number(web3, block_number=1, timeout=120, poll_interval=None):
     if is_tester_web3(web3):
+        if hasattr(web3, 'manager'):
+            rm = web3.manager
+        else:
+            rm = web3._requestManager
+
         while web3.eth.blockNumber < block_number:
-            web3._requestManager.request_blocking("evm_mine", [])
+            rm.request_blocking("evm_mine", [])
         return web3.eth.getBlock(block_number)
     return poll_until(
         poll_fn=lambda: web3.blockNumber,


### PR DESCRIPTION
### What was wrong?

The `web3._requestManager` was renamed to `web3.manager`

### How was it fixed?

Added a check for the attribute and fall back to the old one if it's not present.

#### Cute Animal Picture

> put a cute animal picture here.
