### PR TITLE
project.json use $ref for user config.json

### DIFF
--- a/populus/project.py
+++ b/populus/project.py
@@ -162,7 +162,10 @@ class Project(object):
     @property
     def project_config(self):
         if self._project_config_cache is None:
-            project_config = Config(config=self._project_config)
+            project_config = Config(
+                config=self._project_config,
+                parent=Config(self._user_config)
+            )
             project_config.unref()
             self._project_config_cache = project_config
 


### PR DESCRIPTION
### What was wrong?
$ref in a project.json file to user's .populus/config.json didn't work


### How was it fixed?
added the user_config as parent to project_config


#### Cute Animal Picture

![rabbit_chicks](https://user-images.githubusercontent.com/3235489/31141258-8d4544b4-a87f-11e7-98be-bc33b7def5ff.jpeg)
