### PR TITLE
bugfix upgrade test

### DIFF
--- a/tests/configuration/test_upgrade_to_user_config.py
+++ b/tests/configuration/test_upgrade_to_user_config.py
@@ -33,7 +33,6 @@ from populus.config.versions import (
     V4,
     V5,
     V6,
-    V7,
     FIRST_USER_CONFIG_VERSION,
 )
 
@@ -68,10 +67,10 @@ def test_upgrade_to_user_config(project, from_legacy_version):
         user_config_file_path=project.user_config_file_path
     )
 
-    expected_user_config = Config(load_user_default_config(V7))
+    expected_user_config = Config(load_user_default_config(FIRST_USER_CONFIG_VERSION))
     expected_user_config.unref()
 
-    expected_project_config = Config(load_default_config(V7))
+    expected_project_config = Config(load_default_config(FIRST_USER_CONFIG_VERSION))
     expected_project_config.unref()
 
     assert upgraded_project.legacy_config_path is None


### PR DESCRIPTION
### What was wrong?
upgrade test from legacy to user config expected version used V7 instead of FIRST_USER_CONFIG_VERSION (works for the current version, but may not for next versions)

### How was it fixed?
replaced V7 with FIRST_USER_CONFIG_VERSION

#### Cute Animal Picture

![tiger](https://user-images.githubusercontent.com/3235489/31141614-902f3346-a880-11e7-9e62-41e0b49afffd.jpeg)
