### PR TITLE
default deploy: no-wait-for-sync

### DIFF
--- a/populus/cli/deploy_cmd.py
+++ b/populus/cli/deploy_cmd.py
@@ -25,7 +25,7 @@ from .main import main
 @click.option(
     'wait_for_sync',
     '--wait-for-sync/--no-wait-for-sync',
-    default=True,
+    default=False,
     help=(
         "Determines whether the deploy command should wait until the chain is "
         "fully synced before deployment"


### PR DESCRIPTION
### What was wrong?
default deployment w/o sync is faster and better for dev/testing

### How was it fixed?
changed default to --no-wait-for-sync

#### Cute Animal Picture

![kanguroo](https://user-images.githubusercontent.com/3235489/31142064-d890cfc2-a881-11e7-8a6d-b2d99e0fcdd5.jpg)
