### PR TITLE
Added Populus to requirements-dev with version 2.0.0a1.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 tox>=1.8.0
 hypothesis>=3.4.2
 pytest-xdist==1.18.1
+populus>=2.0.0a1


### PR DESCRIPTION
### What was wrong?
When I installed the requirements from the `requirements-*.txt` files in my virtual environment, it didn't install Populus since it was not in the requirements files. But of course that one is needed 😄 

### How was it fixed?
I added Populus with version 2.0.0a1 or higher to `requirements-dev.txt` so that it gets installed automatically as well.

#### Cute Animal Picture

![](https://media.giphy.com/media/10GN73YGycPXQk/giphy.gif)