### PR TITLE
Updated Quickstart doc

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -334,15 +334,15 @@ except for ``solc``:
 
 Install Solidity
 ~~~~~~~~~~~~~~~~
-You'll have to install solidity, recommended from release 4.11 or greater.
+You'll have to install solidity, recommended from release 0.4.11 or greater.
 
-Installtion scripts for binary:
+Installation scripts for binary:
 '''''''''''''''''''''''''''''''
 
     https://github.com/pipermerriam/py-solc#installing-the-solc-binary
 
 
-Installtion scripts building it:
+Installation scripts building it:
 ''''''''''''''''''''''''''''''''
 
 First, clone the repository and switch to the proper branch:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
 tox>=1.8.0
 hypothesis>=3.4.2
 pytest-xdist==1.18.1
-populus>=2.0.0a1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 tox>=1.8.0
 hypothesis>=3.4.2
 pytest-xdist==1.18.1
+populus>=2.0.0a1


### PR DESCRIPTION
### What was wrong?
**Typos:** There were 2 incredibly important typos in the Quickstart doc. 
**Solc Version:** Solidity uses version numbers like `0.4.11`, but in the docs the version was `4.11`. I found it terribly important to add that leading `0.` for clarification. 

### How was it fixed?
Typos: Fixed them.
Solc Version: Added a leading `0.` to the version number. 

#### Cute Animal Picture

![](https://media.giphy.com/media/10GN73YGycPXQk/giphy.gif)