### PR TITLE
Fixed 2 typos in Quickstart doc.

### DIFF
--- a/docs/chain.introduction.rst
+++ b/docs/chain.introduction.rst
@@ -88,7 +88,8 @@ Running programatically from code
 
 The ``populus.Project.get_chain(chain_name, chain_config=None)`` method returns
 a ``populus.chain.Chain`` instance that can be used within your code to run any
-populus chain.
+populus chain. Also read up on the `Web3.py`_ library, which offers additional
+functions to communicate with an Ethereum blockchain.
 
 Lets look at a basic example of using the ``temp`` chain.
 
@@ -145,3 +146,5 @@ Here is an example of running the ``tester`` blockchain.
     blockNumber: 2
 
 .. note:: The ``testrpc`` chain can be run in the same manner.
+
+.. _Web3.py: http://web3py.readthedocs.io/en/latest/

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -334,15 +334,15 @@ except for ``solc``:
 
 Install Solidity
 ~~~~~~~~~~~~~~~~
-You'll have to install solidity, recommended from release 4.11 or greater.
+You'll have to install solidity, recommended from release 0.4.11 or greater.
 
-Installtion scripts for binary:
+Installation scripts for binary:
 '''''''''''''''''''''''''''''''
 
     https://github.com/pipermerriam/py-solc#installing-the-solc-binary
 
 
-Installtion scripts building it:
+Installation scripts building it:
 ''''''''''''''''''''''''''''''''
 
 First, clone the repository and switch to the proper branch:


### PR DESCRIPTION
Try No. 2. This time with a clean commit history. 

### What was wrong?
**Typos:** There were 2 incredibly important typos in the Quickstart doc. 
**Solc Version:** Solidity uses version numbers like `0.4.11`, but in the docs the version was `4.11`. I found it terribly important to add that leading `0.` for clarification. 

### How was it fixed?
Typos: Fixed them.
Solc Version: Added a leading `0.` to the version number. 

#### Cute Animal Picture

![](https://media.giphy.com/media/10GN73YGycPXQk/giphy.gif)