### PR TITLE
bugfix FileNotFoundError on py2

### DIFF
--- a/populus/plugin.py
+++ b/populus/plugin.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import sys
 
 from populus.project import Project
 
@@ -16,6 +17,10 @@ from populus.utils.json import (
 from populus.config.helpers import (
     get_json_config_file_path,
 )
+
+
+if sys.version_info.major == 2:
+    FileNotFoundError = OSError
 
 
 def pytest_addoption(parser):

--- a/populus/project.py
+++ b/populus/project.py
@@ -3,6 +3,8 @@ import os
 import shutil
 import itertools
 import warnings
+import sys
+
 from eth_utils import (
     to_tuple,
 )
@@ -63,6 +65,10 @@ from populus.config.helpers import (
 from populus.utils.testing import (
     get_tests_dir,
 )
+
+
+if sys.version_info.major == 2:
+    FileNotFoundError = OSError
 
 
 class Project(object):

--- a/tests/project/test_project_directory_properties.py
+++ b/tests/project/test_project_directory_properties.py
@@ -40,4 +40,4 @@ def test_project_directory_properties(project_dir):
 def test_py_version_file_error():
 
     with pytest.raises(OSError):
-        p = Project()  # noqa: F841
+        Project()

--- a/tests/project/test_project_directory_properties.py
+++ b/tests/project/test_project_directory_properties.py
@@ -35,3 +35,9 @@ def test_project_directory_properties(project_dir):
 
     base_blockchain_storage_dir = get_base_blockchain_storage_dir(project_dir)
     assert is_same_path(project.base_blockchain_storage_dir, base_blockchain_storage_dir)
+
+
+def test_py_version_file_error():
+
+    with pytest.raises(OSError):
+        p = Project()  # noqa: F841


### PR DESCRIPTION
### What was wrong?
used FileNotFoundError, not compatible with py2

### How was it fixed?
Assigned to OSError if py2

#### Cute Animal Picture
![4090832858](https://user-images.githubusercontent.com/3235489/31734995-20afb55c-b449-11e7-8696-975d63fa0b14.jpg)




