### PR TITLE
compile: use find_solidity_source_files() from filesystem module

### DIFF
--- a/populus/utils/compile.py
+++ b/populus/utils/compile.py
@@ -36,7 +36,7 @@ from .deploy import (
     compute_deploy_order,
 )
 from .filesystem import (
-    recursive_find_files,
+    find_solidity_source_files,
     ensure_file_exists,
 )
 from .json import (
@@ -71,15 +71,6 @@ def get_compiled_contracts_asset_path(build_asset_dir):
         COMPILED_CONTRACTS_ASSET_FILENAME,
     )
     return compiled_contracts_asset_path
-
-
-@to_tuple
-def find_solidity_source_files(base_dir):
-    return (
-        os.path.relpath(source_file_path)
-        for source_file_path
-        in recursive_find_files(base_dir, "*.sol")
-    )
 
 
 def get_project_source_paths(contracts_source_dir):


### PR DESCRIPTION
### What was wrong?

`compile` module used an implementation of `find_solidity_source_files()` identical to that in the `filesystem` module.

### How was it fixed?

`compile` now imports the [twin from `filesystem`](https://github.com/pipermerriam/populus/blob/8b8b5c5124196dea6ffb15bf34787c13c768cc69/populus/utils/filesystem.py#L95).

Locally, tests seem to pass with same number of skipped/warnings as before the change. (Haven't checked anything more than `make test`.)

#### Cute Animal Picture

[_(waves)_ "Hello! Some duplication here!.."](http://www.zikhsan.net/2012/01/double-headed-animals.html)

![two-headed turtle high-fives itselves](http://3.bp.blogspot.com/-nMM0yL7rQaM/Txd7ohKXYOI/AAAAAAAADBw/LBrO9uxFj_E/s320/ap-amazing-two-headed-animals-291211-08_042736-742015.jpg)
