### PR TITLE
observers_gevent: specify exceptions to try/except block, to calm `flake` and Travis

### DIFF
--- a/populus/utils/observers/observers_gevent.py
+++ b/populus/utils/observers/observers_gevent.py
@@ -40,7 +40,9 @@ class GeventObserver(object):
             try:
                 with gevent.Timeout(2):
                     hub.wait(watcher)
-            except:
+            except gevent.hub.LoopExit:
+                break
+            except gevent.Timeout:
                 continue
             if os.path.isdir(path):
                 new = set(os.listdir(path))


### PR DESCRIPTION
### What was wrong?

Travis [was flaking out](https://travis-ci.org/pipermerriam/populus/jobs/296761099#L668) (pun intended), as shown for unrelated changes in PR #370. See there (https://github.com/pipermerriam/populus/pull/370#issuecomment-341974899) for details.

### How was it fixed?

File `observers_gevent.py` [references](https://github.com/pipermerriam/populus/blob/650d8830b1418a37819efedc3d18a3c346209f56/populus/utils/observers/observers_gevent.py#L2) a [gist](https://gist.github.com/fpom/92a690a8cf89cebd7d4a) by @fpom from May ~~2017~~ 2015, which seems to be an early version of code on [this page](https://www.ibisc.univ-evry.fr/~fpommereau/blog/2015-05-28-watching-filesystem-updates-with-gevent.html) of theirs.

(Note the page is a few years old. `gevent` has likely moved on since then.)

This PR pulls in the minimal change from the page, as compared to the gist: that is, the specific exceptions for (external?) halting and timeout.

There's now no bare `except` , which should calm `flake` down, and let Travis builds pass.

Tangent: [gevent's docs on `Timeout`s](http://www.gevent.org/gevent.html#timeouts) seem to suggest that using `with gevent.Timeout(...)` blocks is best when _avoiding_ `try/except` blocks. Doing it like is done now seems to negate the purpose.

However, _that_ is none of my business. (It's the first time I've experienced `gevent` at close range.)

#### Cute Animal Picture

Source: [San Diego zoo](http://animals.sandiegozoo.org/animals/macaw)

![A macaw/parrot brushes with its beak between its claw](http://animals.sandiegozoo.org/sites/default/files/2016-11/animals_hero_macaws%20copy.jpg)
