### PR TITLE
Fix incorrect polling function in utils

### DIFF
--- a/populus/utils/observers/observers_gevent.py
+++ b/populus/utils/observers/observers_gevent.py
@@ -40,7 +40,7 @@ class GeventObserver(object):
             try:
                 with gevent.Timeout(2):
                     hub.wait(watcher)
-            except:
+            except:  # noqa: E722
                 continue
             if os.path.isdir(path):
                 new = set(os.listdir(path))

--- a/populus/utils/wait.py
+++ b/populus/utils/wait.py
@@ -46,7 +46,7 @@ def wait_for_block_number(web3, block_number=1, timeout=120, poll_interval=None)
             rm.request_blocking("evm_mine", [])
         return web3.eth.getBlock(block_number)
     return poll_until(
-        poll_fn=lambda: web3.blockNumber,
+        poll_fn=lambda: web3.eth.blockNumber,
         success_fn=lambda v: v >= block_number,
         timeout=timeout,
         poll_interval_fn=lambda: poll_interval if poll_interval is not None else random.random(),

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 tox>=1.8.0
 hypothesis>=3.4.2
 pytest-xdist==1.18.1
+flake8==3.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -26,5 +26,6 @@ basepython =
 
 [testenv:flake8]
 basepython=python
-deps=flake8
+deps =
+    -r{toxinidir}/requirements-gevent.txt
 commands=flake8 {toxinidir}/populus {toxinidir}/tests


### PR DESCRIPTION
Fixes #375

### What was wrong?

The lambda in the polling utils was incorrectly accessing `web3.blockNumber`

### How was it fixed?

Redirected to use `web3.eth.blockNumber`

#### Cute Animal Picture

![unlikely-animal-friends-171-1024x727](https://user-images.githubusercontent.com/824194/32631676-333a157a-c55e-11e7-9484-b375ef0af855.jpg)
