### PR TITLE
fix test running not using the correct root directory

### DIFF
--- a/populus/plugin.py
+++ b/populus/plugin.py
@@ -19,13 +19,11 @@ from populus.config.helpers import (
 
 
 def pytest_addoption(parser):
-
     parser.addoption("--populus-project", help="populus project root directory")
     parser.addini("populus_project", "populus project root directory")
 
 
 def get_populus_option(cmdline_option, ini_option, environ_var, pytestconfig, default=None):
-
     if pytestconfig.getoption(cmdline_option, default=False):
             return pytestconfig.getoption(cmdline_option)
     else:
@@ -43,13 +41,12 @@ CACHE_KEY_CONTRACTS = "populus/project/compiled_contracts"
 
 @pytest.fixture()
 def project(request, pytestconfig):
-
     project_dir = get_populus_option(
         cmdline_option="--populus-project",
         ini_option="populus_project",
         environ_var="PYTEST_POPULUS_PROJECT",
         pytestconfig=pytestconfig,
-        default=pytestconfig.args[0]
+        default=os.getcwd(),
     )
 
     if not os.path.exists(get_json_config_file_path(project_dir)):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,7 @@ def temporary_dir(tmpdir):
 
 @pytest.fixture()
 def project_dir(tmpdir, monkeypatch):
+    assert False
     _project_dir = str(tmpdir.mkdir("project-dir"))
 
     # setup project directories

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,7 @@ from populus.config.versions import (
     LATEST_VERSION,
 )
 
-POPULUS_SOURCE_ROOT = os.path.dirname(__file__)
+POPULUS_SOURCE_ROOT = os.path.dirname(os.path.dirname(__file__))
 
 
 @pytest.fixture()
@@ -66,7 +66,6 @@ def temporary_dir(tmpdir):
 
 @pytest.fixture()
 def project_dir(tmpdir, monkeypatch):
-    assert False
     _project_dir = str(tmpdir.mkdir("project-dir"))
 
     # setup project directories
@@ -97,7 +96,11 @@ CACHE_KEY_CONTRACTS = "populus/project/compiled_contracts"
 
 
 @pytest.fixture()
-def project(request, project_dir, user_config_path):
+def project(request,
+            project_dir,
+            user_config_path,
+            _loaded_contract_fixtures,
+            _loaded_test_contract_fixtures):
 
     contracts = request.config.cache.get(CACHE_KEY_CONTRACTS, None)
     mtime = request.config.cache.get(CACHE_KEY_MTIME, None)
@@ -295,20 +298,6 @@ def _loaded_test_contract_fixtures(project_dir, request):
             raise ValueError("File already present at '{0}'".format(dst_path))
 
         shutil.copy(src_path, dst_path)
-
-
-def pytest_fixture_setup(fixturedef, request):
-    """
-    Injects the following fixtures ahead of the `project` fixture.
-
-    - project_dir
-    - _loaded_contract_fixtures
-    - _loaded_test_contract_fixtures
-    """
-    if fixturedef.argname == 'project':
-        request.getfixturevalue('project_dir')
-        request.getfixturevalue('_loaded_contract_fixtures')
-        request.getfixturevalue('_loaded_test_contract_fixtures')
 
 
 @pytest.fixture()


### PR DESCRIPTION
Fixes #341 

### What was wrong?

The way populus was finding the root project directory for the testing fixtures was broken and using the wrong directory.  This lead to confusing errors like https://github.com/pipermerriam/populus/issues/341

### How was it fixed?

Changed from using the incorrect value from the args to use `os.getcwd()`

#### Cute Animal Picture

![3291832342_59530bea2e](https://user-images.githubusercontent.com/824194/32916405-360b55f4-cad9-11e7-91b0-70b20b29dbde.jpg)

