### PR TITLE
Fix python2 compat missing FileNotFoundError

### DIFF
--- a/populus/plugin.py
+++ b/populus/plugin.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import pytest
 
 from populus.project import Project
@@ -16,6 +17,10 @@ from populus.utils.json import (
 from populus.config.helpers import (
     get_json_config_file_path,
 )
+
+
+if sys.version_info.major == 2:
+    FileNotFoundError = OSError
 
 
 def pytest_addoption(parser):

--- a/populus/project.py
+++ b/populus/project.py
@@ -1,8 +1,10 @@
 import copy
+import itertools
 import os
 import shutil
-import itertools
+import sys
 import warnings
+
 from eth_utils import (
     to_tuple,
 )
@@ -63,6 +65,10 @@ from populus.config.helpers import (
 from populus.utils.testing import (
     get_tests_dir,
 )
+
+
+if sys.version_info.major == 2:
+    FileNotFoundError = OSError
 
 
 class Project(object):


### PR DESCRIPTION
### What was wrong?

`FileNotFoundError` is a new python3 exception.  There were places it was used where the python2 compat was not present.

### How was it fixed?

Added python2 compat to alias `OSError` as `FileNotFoundError` 

#### Cute Animal Picture

![our-fine-furry-friend-the-red-panda-is-going-extinct-but-you-can-help-16](https://user-images.githubusercontent.com/824194/32917032-2081a5f6-cadb-11e7-85b3-79fee6fc2ef7.jpg)
