### PR TITLE
Fix out of context doc text.

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -150,8 +150,7 @@ Web3
 
 * ``web3``
 
-Convenience fixture for the ``chain.provider`` property.  A Web3.py instance
-configured to connect to ``chain`` fixture.
+A Web3.py instance configured to connect to ``chain`` fixture.
 
 .. code-block:: python
 


### PR DESCRIPTION
### What was wrong?
Docs were inconsistent. Probably a copy/paste error.


### How was it fixed?
Make the docs relevant to the context.


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/62378/36062891-fc9d615e-0e6c-11e8-99e3-26daaeaff116.png)
